### PR TITLE
fixed go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,5 @@
 module github.com/amimof/huego
+
+go 1.12
+
+require github.com/jarcoal/httpmock v1.0.4

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/jarcoal/httpmock v1.0.4 h1:jp+dy/+nonJE4g4xbVtl9QdrUNbn6/3hDT5R4nDIZnA=
+github.com/jarcoal/httpmock v1.0.4/go.mod h1:ATjnClrvW/3tijVmpL/va5Z3aAyGvqU3gCT8nX0Txik=

--- a/huego_test.go
+++ b/huego_test.go
@@ -3,7 +3,7 @@ package huego_test
 import (
 	"fmt"
 	"github.com/amimof/huego"
-	"gopkg.in/jarcoal/httpmock.v1"
+	"github.com/jarcoal/httpmock"
 	"os"
 	"path"
 	"testing"


### PR DESCRIPTION
this fixes the following error:
```
go: downloading gopkg.in/jarcoal/httpmock.v1 v1.0.4
github.com/amimof/huego tested by
        github.com/amimof/huego.test imports
        gopkg.in/jarcoal/httpmock.v1: go.mod has non-....v1 module path "github.com/jarcoal/httpmock" at revision v1.0.4
```