### PR TITLE
Fixes some GetXXXXs functions

### DIFF
--- a/bridge.go
+++ b/bridge.go
@@ -669,7 +669,8 @@ func (b *Bridge) GetResourcelinks() ([]*Resourcelink, error) {
 		if err != nil {
 			return nil, err
 		}
-		resourcelinks = append(resourcelinks, &s)
+		sCopy := s
+		resourcelinks = append(resourcelinks, &sCopy)
 	}
 
 	return resourcelinks, nil
@@ -827,7 +828,8 @@ func (b *Bridge) GetRules() ([]*Rule, error) {
 		if err != nil {
 			return nil, err
 		}
-		rules = append(rules, &s)
+		sCopy := s
+		rules = append(rules, &sCopy)
 	}
 
 	return rules, nil
@@ -1215,7 +1217,8 @@ func (b *Bridge) GetSchedules() ([]*Schedule, error) {
 		if err != nil {
 			return nil, err
 		}
-		schedules = append(schedules, &s)
+		sCopy := s
+		schedules = append(schedules, &sCopy)
 	}
 
 	return schedules, nil
@@ -1496,7 +1499,8 @@ func (b *Bridge) GetNewSensors() (*NewSensor, error) {
 			if err != nil {
 				return nil, err
 			}
-			sensors = append(sensors, &l)
+			lCopy := l
+			sensors = append(sensors, &lCopy)
 		}
 	}
 

--- a/config_test.go
+++ b/config_test.go
@@ -1,8 +1,10 @@
 package huego_test
 
 import (
-	"github.com/amimof/huego"
 	"testing"
+
+	"github.com/amimof/huego"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetConfig(t *testing.T) {
@@ -86,6 +88,8 @@ func TestGetUsers(t *testing.T) {
 		t.Logf("  CreateDate: %s", u.CreateDate)
 		t.Logf("  LastUseDate: %s", u.LastUseDate)
 	}
+	assert.Equal(t, "PhilipsHueAndroidApp#TCTALCATELONETOU", users[0].Name)
+	assert.Equal(t, "MyApplication", users[1].Name)
 }
 
 func TestDeleteUser(t *testing.T) {

--- a/config_test.go
+++ b/config_test.go
@@ -88,8 +88,17 @@ func TestGetUsers(t *testing.T) {
 		t.Logf("  CreateDate: %s", u.CreateDate)
 		t.Logf("  LastUseDate: %s", u.LastUseDate)
 	}
-	assert.Equal(t, "PhilipsHueAndroidApp#TCTALCATELONETOU", users[0].Name)
-	assert.Equal(t, "MyApplication", users[1].Name)
+	contains := func(name string, ss []huego.Whitelist) bool {
+		for _, s := range ss {
+			if s.Name == name {
+				return true
+			}
+		}
+		return false
+	}
+
+	assert.True(t, contains("PhilipsHueAndroidApp#TCTALCATELONETOU", users))
+	assert.True(t, contains("MyApplication", users))
 }
 
 func TestDeleteUser(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/amimof/huego
 
 go 1.12
 
-require github.com/jarcoal/httpmock v1.0.4
+require (
+	github.com/jarcoal/httpmock v1.0.4
+	github.com/stretchr/testify v1.4.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,12 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/jarcoal/httpmock v1.0.4 h1:jp+dy/+nonJE4g4xbVtl9QdrUNbn6/3hDT5R4nDIZnA=
 github.com/jarcoal/httpmock v1.0.4/go.mod h1:ATjnClrvW/3tijVmpL/va5Z3aAyGvqU3gCT8nX0Txik=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
+github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/group_test.go
+++ b/group_test.go
@@ -1,8 +1,10 @@
 package huego_test
 
 import (
-	"github.com/amimof/huego"
 	"testing"
+
+	"github.com/amimof/huego"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetGroups(t *testing.T) {
@@ -41,6 +43,8 @@ func TestGetGroups(t *testing.T) {
 		t.Logf("    Reachable: %t", g.State.Reachable)
 		t.Logf("  ID: %d", g.ID)
 	}
+	assert.Equal(t, "Group 1", groups[0].Name)
+	assert.Equal(t, "Group 2", groups[1].Name)
 }
 
 func TestGetGroup(t *testing.T) {

--- a/group_test.go
+++ b/group_test.go
@@ -43,8 +43,18 @@ func TestGetGroups(t *testing.T) {
 		t.Logf("    Reachable: %t", g.State.Reachable)
 		t.Logf("  ID: %d", g.ID)
 	}
-	assert.Equal(t, "Group 1", groups[0].Name)
-	assert.Equal(t, "Group 2", groups[1].Name)
+
+	contains := func(name string, ss []huego.Group) bool {
+		for _, s := range ss {
+			if s.Name == name {
+				return true
+			}
+		}
+		return false
+	}
+
+	assert.True(t, contains("Group 1", groups))
+	assert.True(t, contains("Group 2", groups))
 }
 
 func TestGetGroup(t *testing.T) {

--- a/huego_test.go
+++ b/huego_test.go
@@ -2,11 +2,12 @@ package huego_test
 
 import (
 	"fmt"
-	"github.com/amimof/huego"
-	"github.com/jarcoal/httpmock"
 	"os"
 	"path"
 	"testing"
+
+	"github.com/amimof/huego"
+	"github.com/jarcoal/httpmock"
 )
 
 // I'm too lazy to have this elsewhere
@@ -171,7 +172,7 @@ func init() {
 		{
 			method: "GET",
 			path:   "/rules",
-			data:   `{ "1": { "name": "Wall Switch Rule", "lasttriggered": "2013-10-17T01:23:20", "creationtime": "2013-10-10T21:11:45", "timestriggered": 27, "owner": "78H56B12BA", "status": "enabled", "conditions": [ { "address": "/sensors/2/state/buttonevent", "operator": "eq", "value": "16" }, { "address": "/sensors/2/state/lastupdated", "operator": "dx" } ], "actions": [ { "address": "/groups/0/action", "method": "PUT", "body": { "scene": "S3" } } ] }} `,
+			data:   `{ "1": { "name": "Wall Switch Rule", "lasttriggered": "2013-10-17T01:23:20", "creationtime": "2013-10-10T21:11:45", "timestriggered": 27, "owner": "78H56B12BA", "status": "enabled", "conditions": [ { "address": "/sensors/2/state/buttonevent", "operator": "eq", "value": "16" }, { "address": "/sensors/2/state/lastupdated", "operator": "dx" } ], "actions": [ { "address": "/groups/0/action", "method": "PUT", "body": { "scene": "S3" } } ] }, "2": { "name": "Wall Switch Rule 2" }} `,
 		},
 		{
 			method: "GET",
@@ -245,7 +246,7 @@ func init() {
 		{
 			method: "GET",
 			path:   "/sensors/new",
-			data:   `{ "7": {"name": "Hue Tap 1"}, "8": {"name": " Button 3"}, "lastscan":"2013-05-22T10:24:00" }`,
+			data:   `{ "7": {"name": "Hue Tap 1"}, "8": {"name": "Button 3"}, "lastscan":"2013-05-22T10:24:00" }`,
 		},
 		{
 			method: "PUT",
@@ -279,7 +280,7 @@ func init() {
 		{
 			method: "GET",
 			path:   "/resourcelinks",
-			data:   `{ "1": { "name": "Sunrise", "description": "Carla's wakeup experience", "class": 1, "owner": "78H56B12BAABCDEF", "links": ["/schedules/2", "/schedules/3", "/scenes/ABCD", "/scenes/EFGH", "/groups/8"] } }`,
+			data:   `{ "1": { "name": "Sunrise", "description": "Carla's wakeup experience", "class": 1, "owner": "78H56B12BAABCDEF", "links": ["/schedules/2", "/schedules/3", "/scenes/ABCD", "/scenes/EFGH", "/groups/8"] }, "2": { "name": "Sunrise 2" } }`,
 		},
 		{
 			method: "GET",

--- a/light_test.go
+++ b/light_test.go
@@ -25,8 +25,17 @@ func TestGetLights(t *testing.T) {
 		t.Logf("  SwConfigID: %s", l.SwConfigID)
 		t.Logf("  ProductID: %s", l.ProductID)
 	}
-	assert.Equal(t, "Huecolorlamp7", lights[0].Name)
-	assert.Equal(t, "Huelightstripplus1", lights[1].Name)
+	contains := func(name string, ss []huego.Light) bool {
+		for _, s := range ss {
+			if s.Name == name {
+				return true
+			}
+		}
+		return false
+	}
+
+	assert.True(t, contains("Huecolorlamp7", lights))
+	assert.True(t, contains("Huelightstripplus1", lights))
 }
 
 func TestGetLight(t *testing.T) {

--- a/light_test.go
+++ b/light_test.go
@@ -1,8 +1,10 @@
 package huego_test
 
 import (
-	"github.com/amimof/huego"
 	"testing"
+
+	"github.com/amimof/huego"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetLights(t *testing.T) {
@@ -23,6 +25,8 @@ func TestGetLights(t *testing.T) {
 		t.Logf("  SwConfigID: %s", l.SwConfigID)
 		t.Logf("  ProductID: %s", l.ProductID)
 	}
+	assert.Equal(t, "Huecolorlamp7", lights[0].Name)
+	assert.Equal(t, "Huelightstripplus1", lights[1].Name)
 }
 
 func TestGetLight(t *testing.T) {

--- a/resourcelink_test.go
+++ b/resourcelink_test.go
@@ -25,8 +25,17 @@ func TestGetResourcelinks(t *testing.T) {
 		t.Logf("  ID: %d", resourcelink.ID)
 	}
 
-	assert.Equal(t, "Sunrise", resourcelinks[0].Name)
-	assert.Equal(t, "Sunrise 2", resourcelinks[1].Name)
+	contains := func(name string, ss []*huego.Resourcelink) bool {
+		for _, s := range ss {
+			if s.Name == name {
+				return true
+			}
+		}
+		return false
+	}
+
+	assert.True(t, contains("Sunrise", resourcelinks))
+	assert.True(t, contains("Sunrise 2", resourcelinks))
 }
 
 func TestGetResourcelink(t *testing.T) {

--- a/resourcelink_test.go
+++ b/resourcelink_test.go
@@ -1,8 +1,10 @@
 package huego_test
 
 import (
-	"github.com/amimof/huego"
 	"testing"
+
+	"github.com/amimof/huego"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetResourcelinks(t *testing.T) {
@@ -22,6 +24,9 @@ func TestGetResourcelinks(t *testing.T) {
 		t.Logf("  Links: %s", resourcelink.Links)
 		t.Logf("  ID: %d", resourcelink.ID)
 	}
+
+	assert.Equal(t, "Sunrise", resourcelinks[0].Name)
+	assert.Equal(t, "Sunrise 2", resourcelinks[1].Name)
 }
 
 func TestGetResourcelink(t *testing.T) {

--- a/rule_test.go
+++ b/rule_test.go
@@ -17,8 +17,18 @@ func TestGetRules(t *testing.T) {
 	for _, rule := range rules {
 		t.Log(rule)
 	}
-	assert.Equal(t, "Wall Switch Rule", rules[0].Name)
-	assert.Equal(t, "Wall Switch Rule 2", rules[1].Name)
+
+	contains := func(name string, ss []*huego.Rule) bool {
+		for _, s := range ss {
+			if s.Name == name {
+				return true
+			}
+		}
+		return false
+	}
+
+	assert.True(t, contains("Wall Switch Rule", rules))
+	assert.True(t, contains("Wall Switch Rule 2", rules))
 }
 
 func TestGetRule(t *testing.T) {

--- a/rule_test.go
+++ b/rule_test.go
@@ -1,8 +1,10 @@
 package huego_test
 
 import (
-	"github.com/amimof/huego"
 	"testing"
+
+	"github.com/amimof/huego"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetRules(t *testing.T) {
@@ -15,6 +17,8 @@ func TestGetRules(t *testing.T) {
 	for _, rule := range rules {
 		t.Log(rule)
 	}
+	assert.Equal(t, "Wall Switch Rule", rules[0].Name)
+	assert.Equal(t, "Wall Switch Rule 2", rules[1].Name)
 }
 
 func TestGetRule(t *testing.T) {

--- a/scene_test.go
+++ b/scene_test.go
@@ -28,8 +28,18 @@ func TestGetScenes(t *testing.T) {
 		t.Logf("  StoreSceneState: %t", scene.StoreSceneState)
 		t.Logf("  ID: %s", scene.ID)
 	}
-	assert.Equal(t, "Kathyon1449133269486", scenes[0].Name)
-	assert.Equal(t, "Cozydinner", scenes[1].Name)
+
+	contains := func(name string, ss []huego.Scene) bool {
+		for _, s := range ss {
+			if s.Name == name {
+				return true
+			}
+		}
+		return false
+	}
+
+	assert.True(t, contains("Kathyon1449133269486", scenes))
+	assert.True(t, contains("Cozydinner", scenes))
 
 }
 

--- a/scene_test.go
+++ b/scene_test.go
@@ -1,8 +1,10 @@
 package huego_test
 
 import (
-	"github.com/amimof/huego"
 	"testing"
+
+	"github.com/amimof/huego"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetScenes(t *testing.T) {
@@ -26,6 +28,9 @@ func TestGetScenes(t *testing.T) {
 		t.Logf("  StoreSceneState: %t", scene.StoreSceneState)
 		t.Logf("  ID: %s", scene.ID)
 	}
+	assert.Equal(t, "Kathyon1449133269486", scenes[0].Name)
+	assert.Equal(t, "Cozydinner", scenes[1].Name)
+
 }
 
 func TestGetScene(t *testing.T) {

--- a/schedule_test.go
+++ b/schedule_test.go
@@ -1,8 +1,10 @@
 package huego_test
 
 import (
-	"github.com/amimof/huego"
 	"testing"
+
+	"github.com/amimof/huego"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetSchedules(t *testing.T) {
@@ -27,6 +29,8 @@ func TestGetSchedules(t *testing.T) {
 		t.Logf("  AutoDelete: %t", schedule.AutoDelete)
 		t.Logf("  ID: %d", schedule.ID)
 	}
+	assert.Equal(t, "Timer", schedules[0].Name)
+	assert.Equal(t, "Alarm", schedules[1].Name)
 }
 
 func TestGetSchedule(t *testing.T) {

--- a/schedule_test.go
+++ b/schedule_test.go
@@ -29,8 +29,19 @@ func TestGetSchedules(t *testing.T) {
 		t.Logf("  AutoDelete: %t", schedule.AutoDelete)
 		t.Logf("  ID: %d", schedule.ID)
 	}
-	assert.Equal(t, "Timer", schedules[0].Name)
-	assert.Equal(t, "Alarm", schedules[1].Name)
+
+	contains := func(name string, ss []*huego.Schedule) bool {
+		for _, s := range ss {
+			if s.Name == name {
+				return true
+			}
+		}
+		return false
+	}
+
+	assert.True(t, contains("Timer", schedules))
+	assert.True(t, contains("Alarm", schedules))
+
 }
 
 func TestGetSchedule(t *testing.T) {

--- a/sensor_test.go
+++ b/sensor_test.go
@@ -1,8 +1,10 @@
 package huego_test
 
 import (
-	"github.com/amimof/huego"
 	"testing"
+
+	"github.com/amimof/huego"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetSensors(t *testing.T) {
@@ -25,6 +27,8 @@ func TestGetSensors(t *testing.T) {
 		t.Logf("SwVersion: %s", sensor.SwVersion)
 		t.Logf("ID: %d", sensor.ID)
 	}
+	assert.Equal(t, "Daylight", sensors[0].Name)
+	assert.Equal(t, "Tap Switch 2", sensors[1].Name)
 }
 
 func TestGetSensor(t *testing.T) {
@@ -93,6 +97,8 @@ func TestGetNewSensors(t *testing.T) {
 		t.Logf("SwVersion: %s", sensor.SwVersion)
 		t.Logf("ID: %d", sensor.ID)
 	}
+	assert.Equal(t, "Hue Tap 1", newSensors.Sensors[0].Name)
+	assert.Equal(t, "Button 3", newSensors.Sensors[1].Name)
 }
 
 func TestUpdateSensor(t *testing.T) {

--- a/sensor_test.go
+++ b/sensor_test.go
@@ -27,8 +27,17 @@ func TestGetSensors(t *testing.T) {
 		t.Logf("SwVersion: %s", sensor.SwVersion)
 		t.Logf("ID: %d", sensor.ID)
 	}
-	assert.Equal(t, "Daylight", sensors[0].Name)
-	assert.Equal(t, "Tap Switch 2", sensors[1].Name)
+	contains := func(name string, ss []huego.Sensor) bool {
+		for _, s := range ss {
+			if s.Name == name {
+				return true
+			}
+		}
+		return false
+	}
+
+	assert.True(t, contains("Daylight", sensors))
+	assert.True(t, contains("Tap Switch 2", sensors))
 }
 
 func TestGetSensor(t *testing.T) {
@@ -97,8 +106,18 @@ func TestGetNewSensors(t *testing.T) {
 		t.Logf("SwVersion: %s", sensor.SwVersion)
 		t.Logf("ID: %d", sensor.ID)
 	}
-	assert.Equal(t, "Hue Tap 1", newSensors.Sensors[0].Name)
-	assert.Equal(t, "Button 3", newSensors.Sensors[1].Name)
+
+	contains := func(name string, ss []*huego.Sensor) bool {
+		for _, s := range ss {
+			if s.Name == name {
+				return true
+			}
+		}
+		return false
+	}
+
+	assert.True(t, contains("Hue Tap 1", newSensors.Sensors))
+	assert.True(t, contains("Button 3", newSensors.Sensors))
 }
 
 func TestUpdateSensor(t *testing.T) {


### PR DESCRIPTION
For iterations over a range will reuse the same variable, so adding its
address to a slice will effectively add the same element over and over
again.
Making a copy before adding the element will ensure that all the
elements are passed.
Added a few tests to verify all the GetXXXXs functions.