### PR TITLE
fix minor bug in scheduling recurring events 

### DIFF
--- a/schedule.go
+++ b/schedule.go
@@ -9,7 +9,7 @@ type Schedule struct {
 	LocalTime   string   `json:"localtime"`
 	StartTime   string   `json:"starttime,omitempty"`
 	Status      string   `json:"status,omitempty"`
-	AutoDelete  bool     `json:"autodelete"`
+	AutoDelete  bool     `json:"autodelete,omitempty"`
 	ID          int      `json:"-"`
 }
 


### PR DESCRIPTION
Currently, I am unable to create a recurring schedule. It results in the following error: 
```
panic: ERROR 6 [/schedules]: "parameter, autodelete, not available"
```
Based on what I am seeing for the `autodelete` param in the [schedule docs](https://developers.meethue.com/develop/hue-api/3-schedules-api/#create-schedule), this perhaps is not relevant to relevant to `recurring` schedules and breaks the `POST`. 

> Only visible for non-recurring schedules.

I used `curl` to confirm this hypothesis. 

I am have tested that setting `omitempty` on the `AutoDelete` field of the `Schedule` struct solved this issue for me.