### PR TITLE
fix bug in `GetSchedules`

### DIFF
--- a/bridge.go
+++ b/bridge.go
@@ -1208,14 +1208,15 @@ func (b *Bridge) GetSchedules() ([]*Schedule, error) {
 		return nil, err
 	}
 
-	schedules := make([]*Schedule, 0, len(r))
+	schedules := make([]*Schedule, len(r))
 
 	for i, s := range r {
 		s.ID, err = strconv.Atoi(i)
 		if err != nil {
 			return nil, err
 		}
-		schedules = append(schedules, &s)
+		s2 := s
+		schedules[s.ID-1] = &s2
 	}
 
 	return schedules, nil


### PR DESCRIPTION
While making my lights more awesome, I noticed a bug in `GetSchedules` that caused all items in the `return` array to be the same `*Schedule`.

From this, I was able to derive [this minimal repo](https://play.golang.org/p/u6cbj8jQNDr).

As best as I can tell, the `append` is coping the pointer to the `Schedule` which is being reset as per the `range`.

There may be a more elegant fix, but simply assigning `s` to another variable and referencing that [works here](https://play.golang.org/p/hgTFJ2Mcwa4)

While I was here, I noticed that the results were not ordered as go maps don't provide that. Since the Hue api returns ordered results, I made the behavior constient.