### PR TITLE
Make the API context.Context aware

### DIFF
--- a/bridge.go
+++ b/bridge.go
@@ -1,6 +1,7 @@
 package huego
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/url"
@@ -48,6 +49,11 @@ func (b *Bridge) Login(u string) *Bridge {
 
 // GetConfig returns the bridge configuration
 func (b *Bridge) GetConfig() (*Config, error) {
+	return b.GetConfigWithContext(context.Background())
+}
+
+// GetConfigContext returns the bridge configuration
+func (b *Bridge) GetConfigWithContext(ctx context.Context) (*Config, error) {
 
 	var config *Config
 
@@ -56,7 +62,7 @@ func (b *Bridge) GetConfig() (*Config, error) {
 		return nil, err
 	}
 
-	res, err := get(url)
+	res, err := get(ctx, url)
 	if err != nil {
 		return nil, err
 	}
@@ -81,6 +87,12 @@ func (b *Bridge) GetConfig() (*Config, error) {
 // CreateUser creates a user by adding n to the list of whitelists in the bridge.
 // The link button on the bridge must have been pressed before calling CreateUser.
 func (b *Bridge) CreateUser(n string) (string, error) {
+	return b.CreateUserContext(context.Background(), n)
+}
+
+// CreateUserContext creates a user by adding n to the list of whitelists in the bridge.
+// The link button on the bridge must have been pressed before calling CreateUser.
+func (b *Bridge) CreateUserContext(ctx context.Context, n string) (string, error) {
 
 	var a []*APIResponse
 
@@ -99,7 +111,7 @@ func (b *Bridge) CreateUser(n string) (string, error) {
 		return "", err
 	}
 
-	res, err := post(url, data)
+	res, err := post(ctx, url, data)
 	if err != nil {
 		return "", err
 	}
@@ -129,6 +141,11 @@ func (b *Bridge) GetUsers() ([]Whitelist, error) {
 
 // UpdateConfig updates the bridge configuration with c
 func (b *Bridge) UpdateConfig(c *Config) (*Response, error) {
+	return b.UpdateConfigContext(context.Background(), c)
+}
+
+// UpdateConfigContext updates the bridge configuration with c
+func (b *Bridge) UpdateConfigContext(ctx context.Context, c *Config) (*Response, error) {
 
 	var a []*APIResponse
 
@@ -142,7 +159,7 @@ func (b *Bridge) UpdateConfig(c *Config) (*Response, error) {
 		return nil, err
 	}
 
-	res, err := put(url, data)
+	res, err := put(ctx, url, data)
 	if err != nil {
 		return nil, err
 	}
@@ -162,6 +179,11 @@ func (b *Bridge) UpdateConfig(c *Config) (*Response, error) {
 
 // DeleteUser removes a whitelist item from whitelists on the bridge
 func (b *Bridge) DeleteUser(n string) error {
+	return b.DeleteUserContext(context.Background(), n)
+}
+
+// DeleteUserContext removes a whitelist item from whitelists on the bridge
+func (b *Bridge) DeleteUserContext(ctx context.Context, n string) error {
 
 	var a []*APIResponse
 
@@ -170,7 +192,7 @@ func (b *Bridge) DeleteUser(n string) error {
 		return err
 	}
 
-	res, err := delete(url)
+	res, err := delete(ctx, url)
 	if err != nil {
 		return err
 	}
@@ -188,6 +210,11 @@ func (b *Bridge) DeleteUser(n string) error {
 
 // GetFullState returns the entire bridge configuration.
 func (b *Bridge) GetFullState() (map[string]interface{}, error) {
+	return b.GetFullStateContext(context.Background())
+}
+
+// GetFullStateContext returns the entire bridge configuration.
+func (b *Bridge) GetFullStateContext(ctx context.Context) (map[string]interface{}, error) {
 
 	var n map[string]interface{}
 
@@ -196,7 +223,7 @@ func (b *Bridge) GetFullState() (map[string]interface{}, error) {
 		return nil, err
 	}
 
-	res, err := get(url)
+	res, err := get(ctx, url)
 	if err != nil {
 		return nil, err
 	}
@@ -217,6 +244,11 @@ func (b *Bridge) GetFullState() (map[string]interface{}, error) {
 
 // GetGroups returns all groups known to the bridge
 func (b *Bridge) GetGroups() ([]Group, error) {
+	return b.GetGroupsContext(context.Background())
+}
+
+// GetGroupsContext returns all groups known to the bridge
+func (b *Bridge) GetGroupsContext(ctx context.Context) ([]Group, error) {
 
 	var m map[string]Group
 
@@ -225,7 +257,7 @@ func (b *Bridge) GetGroups() ([]Group, error) {
 		return nil, err
 	}
 
-	res, err := get(url)
+	res, err := get(ctx, url)
 	if err != nil {
 		return nil, err
 	}
@@ -252,6 +284,11 @@ func (b *Bridge) GetGroups() ([]Group, error) {
 
 // GetGroup returns one group known to the bridge by its id
 func (b *Bridge) GetGroup(i int) (*Group, error) {
+	return b.GetGroupContext(context.Background(), i)
+}
+
+// GetGroupContext returns one group known to the bridge by its id
+func (b *Bridge) GetGroupContext(ctx context.Context, i int) (*Group, error) {
 
 	g := &Group{
 		ID: i,
@@ -262,7 +299,7 @@ func (b *Bridge) GetGroup(i int) (*Group, error) {
 		return nil, err
 	}
 
-	res, err := get(url)
+	res, err := get(ctx, url)
 	if err != nil {
 		return nil, err
 	}
@@ -279,6 +316,11 @@ func (b *Bridge) GetGroup(i int) (*Group, error) {
 
 // SetGroupState allows for setting the state of one group, controlling the state of all lights in that group.
 func (b *Bridge) SetGroupState(i int, l State) (*Response, error) {
+	return b.SetGroupStateContext(context.Background(), i, l)
+}
+
+// SetGroupStateContext allows for setting the state of one group, controlling the state of all lights in that group.
+func (b *Bridge) SetGroupStateContext(ctx context.Context, i int, l State) (*Response, error) {
 
 	var a []*APIResponse
 
@@ -293,7 +335,7 @@ func (b *Bridge) SetGroupState(i int, l State) (*Response, error) {
 		return nil, err
 	}
 
-	res, err := put(url, data)
+	res, err := put(ctx, url, data)
 	if err != nil {
 		return nil, err
 	}
@@ -313,6 +355,11 @@ func (b *Bridge) SetGroupState(i int, l State) (*Response, error) {
 
 // UpdateGroup updates one group known to the bridge
 func (b *Bridge) UpdateGroup(i int, l Group) (*Response, error) {
+	return b.UpdateGroupContext(context.Background(), i, l)
+}
+
+// UpdateGroupContext updates one group known to the bridge
+func (b *Bridge) UpdateGroupContext(ctx context.Context, i int, l Group) (*Response, error) {
 
 	var a []*APIResponse
 
@@ -327,7 +374,7 @@ func (b *Bridge) UpdateGroup(i int, l Group) (*Response, error) {
 		return nil, err
 	}
 
-	res, err := put(url, data)
+	res, err := put(ctx, url, data)
 	if err != nil {
 		return nil, err
 	}
@@ -347,6 +394,11 @@ func (b *Bridge) UpdateGroup(i int, l Group) (*Response, error) {
 
 // CreateGroup creates one new group with attributes defined by g
 func (b *Bridge) CreateGroup(g Group) (*Response, error) {
+	return b.CreateGroupContext(context.Background(), g)
+}
+
+// CreateGroupContext creates one new group with attributes defined by g
+func (b *Bridge) CreateGroupContext(ctx context.Context, g Group) (*Response, error) {
 
 	var a []*APIResponse
 
@@ -360,7 +412,7 @@ func (b *Bridge) CreateGroup(g Group) (*Response, error) {
 		return nil, err
 	}
 
-	res, err := post(url, data)
+	res, err := post(ctx, url, data)
 	if err != nil {
 		return nil, err
 	}
@@ -380,6 +432,11 @@ func (b *Bridge) CreateGroup(g Group) (*Response, error) {
 
 // DeleteGroup deletes one group with the id of i
 func (b *Bridge) DeleteGroup(i int) error {
+	return b.DeleteGroupContext(context.Background(), i)
+}
+
+// DeleteGroupContext deletes one group with the id of i
+func (b *Bridge) DeleteGroupContext(ctx context.Context, i int) error {
 
 	var a []*APIResponse
 
@@ -389,7 +446,7 @@ func (b *Bridge) DeleteGroup(i int) error {
 		return err
 	}
 
-	res, err := delete(url)
+	res, err := delete(ctx, url)
 	if err != nil {
 		return err
 	}
@@ -412,6 +469,11 @@ func (b *Bridge) DeleteGroup(i int) error {
 
 // GetLights returns all lights known to the bridge
 func (b *Bridge) GetLights() ([]Light, error) {
+	return b.GetLightsContext(context.Background())
+}
+
+// GetLightsContext returns all lights known to the bridge
+func (b *Bridge) GetLightsContext(ctx context.Context) ([]Light, error) {
 
 	m := map[string]Light{}
 
@@ -420,7 +482,7 @@ func (b *Bridge) GetLights() ([]Light, error) {
 		return nil, err
 	}
 
-	res, err := get(url)
+	res, err := get(ctx, url)
 	if err != nil {
 		return nil, err
 	}
@@ -447,6 +509,11 @@ func (b *Bridge) GetLights() ([]Light, error) {
 
 // GetLight returns one light with the id of i
 func (b *Bridge) GetLight(i int) (*Light, error) {
+	return b.GetLightContext(context.Background(), i)
+}
+
+// GetLightContext returns one light with the id of i
+func (b *Bridge) GetLightContext(ctx context.Context, i int) (*Light, error) {
 
 	light := &Light{
 		ID: i,
@@ -457,7 +524,7 @@ func (b *Bridge) GetLight(i int) (*Light, error) {
 		return nil, err
 	}
 
-	res, err := get(url)
+	res, err := get(ctx, url)
 	if err != nil {
 		return light, err
 	}
@@ -474,6 +541,11 @@ func (b *Bridge) GetLight(i int) (*Light, error) {
 
 // SetLightState allows for controlling one light's state
 func (b *Bridge) SetLightState(i int, l State) (*Response, error) {
+	return b.SetLightStateContext(context.Background(), i, l)
+}
+
+// SetLightStateContext allows for controlling one light's state
+func (b *Bridge) SetLightStateContext(ctx context.Context, i int, l State) (*Response, error) {
 
 	var a []*APIResponse
 
@@ -489,7 +561,7 @@ func (b *Bridge) SetLightState(i int, l State) (*Response, error) {
 	if err != nil {
 		return nil, err
 	}
-	res, err := put(url, data)
+	res, err := put(ctx, url, data)
 	if err != nil {
 		return nil, err
 	}
@@ -511,6 +583,12 @@ func (b *Bridge) SetLightState(i int, l State) (*Response, error) {
 // FindLights starts a search for new lights on the bridge.
 // Use GetNewLights() verify if new lights have been detected.
 func (b *Bridge) FindLights() (*Response, error) {
+	return b.FindLightsContext(context.Background())
+}
+
+// FindLightsContext starts a search for new lights on the bridge.
+// Use GetNewLights() verify if new lights have been detected.
+func (b *Bridge) FindLightsContext(ctx context.Context) (*Response, error) {
 
 	var a []*APIResponse
 
@@ -519,7 +597,7 @@ func (b *Bridge) FindLights() (*Response, error) {
 		return nil, err
 	}
 
-	res, err := post(url, nil)
+	res, err := post(ctx, url, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -540,6 +618,11 @@ func (b *Bridge) FindLights() (*Response, error) {
 
 // GetNewLights returns a list of lights that were discovered last time FindLights() was executed.
 func (b *Bridge) GetNewLights() (*NewLight, error) {
+	return b.GetNewLightsContext(context.Background())
+}
+
+// GetNewLightsContext returns a list of lights that were discovered last time FindLights() was executed.
+func (b *Bridge) GetNewLightsContext(ctx context.Context) (*NewLight, error) {
 
 	var n map[string]interface{}
 
@@ -548,7 +631,7 @@ func (b *Bridge) GetNewLights() (*NewLight, error) {
 		return nil, err
 	}
 
-	res, err := get(url)
+	res, err := get(ctx, url)
 	if err != nil {
 		return nil, err
 	}
@@ -577,6 +660,11 @@ func (b *Bridge) GetNewLights() (*NewLight, error) {
 
 // DeleteLight deletes one lights from the bridge
 func (b *Bridge) DeleteLight(i int) error {
+	return b.DeleteLightContext(context.Background(), i)
+}
+
+// DeleteLightContext deletes one lights from the bridge
+func (b *Bridge) DeleteLightContext(ctx context.Context, i int) error {
 
 	var a []*APIResponse
 
@@ -586,7 +674,7 @@ func (b *Bridge) DeleteLight(i int) error {
 		return err
 	}
 
-	res, err := delete(url)
+	res, err := delete(ctx, url)
 	if err != nil {
 		return err
 	}
@@ -604,6 +692,11 @@ func (b *Bridge) DeleteLight(i int) error {
 
 // UpdateLight updates one light's attributes and state properties
 func (b *Bridge) UpdateLight(i int, light Light) (*Response, error) {
+	return b.UpdateLightContext(context.Background(), i, light)
+}
+
+// UpdateLightContext updates one light's attributes and state properties
+func (b *Bridge) UpdateLightContext(ctx context.Context, i int, light Light) (*Response, error) {
 
 	var a []*APIResponse
 
@@ -618,7 +711,7 @@ func (b *Bridge) UpdateLight(i int, light Light) (*Response, error) {
 		return nil, err
 	}
 
-	res, err := put(url, data)
+	res, err := put(ctx, url, data)
 	if err != nil {
 		return nil, err
 	}
@@ -644,6 +737,11 @@ func (b *Bridge) UpdateLight(i int, light Light) (*Response, error) {
 
 // GetResourcelinks returns all resourcelinks known to the bridge
 func (b *Bridge) GetResourcelinks() ([]*Resourcelink, error) {
+	return b.GetResourcelinksContext(context.Background())
+}
+
+// GetResourcelinksContext returns all resourcelinks known to the bridge
+func (b *Bridge) GetResourcelinksContext(ctx context.Context) ([]*Resourcelink, error) {
 
 	var r map[string]Resourcelink
 
@@ -652,7 +750,7 @@ func (b *Bridge) GetResourcelinks() ([]*Resourcelink, error) {
 		return nil, err
 	}
 
-	res, err := get(url)
+	res, err := get(ctx, url)
 	if err != nil {
 		return nil, err
 	}
@@ -679,6 +777,11 @@ func (b *Bridge) GetResourcelinks() ([]*Resourcelink, error) {
 
 // GetResourcelink returns one resourcelink by its id defined by i
 func (b *Bridge) GetResourcelink(i int) (*Resourcelink, error) {
+	return b.GetResourcelinkContext(context.Background(), i)
+}
+
+// GetResourcelinkContext returns one resourcelink by its id defined by i
+func (b *Bridge) GetResourcelinkContext(ctx context.Context, i int) (*Resourcelink, error) {
 
 	g := &Resourcelink{
 		ID: i,
@@ -689,7 +792,7 @@ func (b *Bridge) GetResourcelink(i int) (*Resourcelink, error) {
 		return nil, err
 	}
 
-	res, err := get(url)
+	res, err := get(ctx, url)
 	if err != nil {
 		return nil, err
 	}
@@ -705,6 +808,11 @@ func (b *Bridge) GetResourcelink(i int) (*Resourcelink, error) {
 
 // CreateResourcelink creates one new resourcelink on the bridge
 func (b *Bridge) CreateResourcelink(s *Resourcelink) (*Response, error) {
+	return b.CreateResourcelinkContext(context.Background(), s)
+}
+
+// CreateResourcelinkContext creates one new resourcelink on the bridge
+func (b *Bridge) CreateResourcelinkContext(ctx context.Context, s *Resourcelink) (*Response, error) {
 
 	var a []*APIResponse
 
@@ -718,7 +826,7 @@ func (b *Bridge) CreateResourcelink(s *Resourcelink) (*Response, error) {
 		return nil, err
 	}
 
-	res, err := post(url, data)
+	res, err := post(ctx, url, data)
 	if err != nil {
 		return nil, err
 	}
@@ -739,6 +847,11 @@ func (b *Bridge) CreateResourcelink(s *Resourcelink) (*Response, error) {
 
 // UpdateResourcelink updates one resourcelink with attributes defined by resourcelink
 func (b *Bridge) UpdateResourcelink(i int, resourcelink *Resourcelink) (*Response, error) {
+	return b.UpdateResourcelinkContext(context.Background(), i, resourcelink)
+}
+
+// UpdateResourcelinkContext updates one resourcelink with attributes defined by resourcelink
+func (b *Bridge) UpdateResourcelinkContext(ctx context.Context, i int, resourcelink *Resourcelink) (*Response, error) {
 	var a []*APIResponse
 
 	data, err := json.Marshal(&resourcelink)
@@ -751,7 +864,7 @@ func (b *Bridge) UpdateResourcelink(i int, resourcelink *Resourcelink) (*Respons
 		return nil, err
 	}
 
-	res, err := put(url, data)
+	res, err := put(ctx, url, data)
 	if err != nil {
 		return nil, err
 	}
@@ -771,6 +884,11 @@ func (b *Bridge) UpdateResourcelink(i int, resourcelink *Resourcelink) (*Respons
 
 // DeleteResourcelink deletes one resourcelink with the id of i
 func (b *Bridge) DeleteResourcelink(i int) error {
+	return b.DeleteResourcelinkContext(context.Background(), i)
+}
+
+// DeleteResourcelinkContext deletes one resourcelink with the id of i
+func (b *Bridge) DeleteResourcelinkContext(ctx context.Context, i int) error {
 
 	var a []*APIResponse
 
@@ -780,7 +898,7 @@ func (b *Bridge) DeleteResourcelink(i int) error {
 		return err
 	}
 
-	res, err := delete(url)
+	res, err := delete(ctx, url)
 	if err != nil {
 		return err
 	}
@@ -803,6 +921,11 @@ func (b *Bridge) DeleteResourcelink(i int) error {
 
 // GetRules returns all rules known to the bridge
 func (b *Bridge) GetRules() ([]*Rule, error) {
+	return b.GetRulesContext(context.Background())
+}
+
+// GetRulesContext returns all rules known to the bridge
+func (b *Bridge) GetRulesContext(ctx context.Context) ([]*Rule, error) {
 
 	var r map[string]Rule
 
@@ -811,7 +934,7 @@ func (b *Bridge) GetRules() ([]*Rule, error) {
 		return nil, err
 	}
 
-	res, err := get(url)
+	res, err := get(ctx, url)
 	if err != nil {
 		return nil, err
 	}
@@ -838,6 +961,11 @@ func (b *Bridge) GetRules() ([]*Rule, error) {
 
 // GetRule returns one rule by its id of i
 func (b *Bridge) GetRule(i int) (*Rule, error) {
+	return b.GetRuleContext(context.Background(), i)
+}
+
+// GetRuleContext returns one rule by its id of i
+func (b *Bridge) GetRuleContext(ctx context.Context, i int) (*Rule, error) {
 
 	g := &Rule{
 		ID: i,
@@ -848,7 +976,7 @@ func (b *Bridge) GetRule(i int) (*Rule, error) {
 		return nil, err
 	}
 
-	res, err := get(url)
+	res, err := get(ctx, url)
 	if err != nil {
 		return nil, err
 	}
@@ -864,6 +992,11 @@ func (b *Bridge) GetRule(i int) (*Rule, error) {
 
 // CreateRule creates one rule with attribues defined in s
 func (b *Bridge) CreateRule(s *Rule) (*Response, error) {
+	return b.CreateRuleContext(context.Background(), s)
+}
+
+// CreateRuleContext creates one rule with attribues defined in s
+func (b *Bridge) CreateRuleContext(ctx context.Context, s *Rule) (*Response, error) {
 
 	var a []*APIResponse
 
@@ -877,7 +1010,7 @@ func (b *Bridge) CreateRule(s *Rule) (*Response, error) {
 		return nil, err
 	}
 
-	res, err := post(url, data)
+	res, err := post(ctx, url, data)
 	if err != nil {
 		return nil, err
 	}
@@ -898,6 +1031,11 @@ func (b *Bridge) CreateRule(s *Rule) (*Response, error) {
 
 // UpdateRule updates one rule by its id of i and rule configuration of rule
 func (b *Bridge) UpdateRule(i int, rule *Rule) (*Response, error) {
+	return b.UpdateRuleContext(context.Background(), i, rule)
+}
+
+// UpdateRuleContext updates one rule by its id of i and rule configuration of rule
+func (b *Bridge) UpdateRuleContext(ctx context.Context, i int, rule *Rule) (*Response, error) {
 
 	var a []*APIResponse
 
@@ -911,7 +1049,7 @@ func (b *Bridge) UpdateRule(i int, rule *Rule) (*Response, error) {
 		return nil, err
 	}
 
-	res, err := put(url, data)
+	res, err := put(ctx, url, data)
 	if err != nil {
 		return nil, err
 	}
@@ -931,6 +1069,11 @@ func (b *Bridge) UpdateRule(i int, rule *Rule) (*Response, error) {
 
 // DeleteRule deletes one rule from the bridge
 func (b *Bridge) DeleteRule(i int) error {
+	return b.DeleteRuleContext(context.Background(), i)
+}
+
+// DeleteRuleContext deletes one rule from the bridge
+func (b *Bridge) DeleteRuleContext(ctx context.Context, i int) error {
 
 	var a []*APIResponse
 
@@ -940,7 +1083,7 @@ func (b *Bridge) DeleteRule(i int) error {
 		return err
 	}
 
-	res, err := delete(url)
+	res, err := delete(ctx, url)
 	if err != nil {
 		return err
 	}
@@ -963,6 +1106,11 @@ func (b *Bridge) DeleteRule(i int) error {
 
 // GetScenes returns all scenes known to the bridge
 func (b *Bridge) GetScenes() ([]Scene, error) {
+	return b.GetScenesContext(context.Background())
+}
+
+// GetScenesContext returns all scenes known to the bridge
+func (b *Bridge) GetScenesContext(ctx context.Context) ([]Scene, error) {
 
 	var m map[string]Scene
 
@@ -971,7 +1119,7 @@ func (b *Bridge) GetScenes() ([]Scene, error) {
 		return nil, err
 	}
 
-	res, err := get(url)
+	res, err := get(ctx, url)
 	if err != nil {
 		return nil, err
 	}
@@ -991,6 +1139,11 @@ func (b *Bridge) GetScenes() ([]Scene, error) {
 
 // GetScene returns one scene by its id of i
 func (b *Bridge) GetScene(i string) (*Scene, error) {
+	return b.GetSceneContext(context.Background(), i)
+}
+
+// GetSceneContext returns one scene by its id of i
+func (b *Bridge) GetSceneContext(ctx context.Context, i string) (*Scene, error) {
 
 	g := &Scene{ID: i}
 	l := struct {
@@ -1002,7 +1155,7 @@ func (b *Bridge) GetScene(i string) (*Scene, error) {
 		return nil, err
 	}
 
-	res, err := get(url)
+	res, err := get(ctx, url)
 	if err != nil {
 		return nil, err
 	}
@@ -1024,6 +1177,11 @@ func (b *Bridge) GetScene(i string) (*Scene, error) {
 
 // UpdateScene updates one scene and its attributes by id of i
 func (b *Bridge) UpdateScene(id string, s *Scene) (*Response, error) {
+	return b.UpdateSceneContext(context.Background(), id, s)
+}
+
+// UpdateSceneContext updates one scene and its attributes by id of i
+func (b *Bridge) UpdateSceneContext(ctx context.Context, id string, s *Scene) (*Response, error) {
 
 	var a []*APIResponse
 
@@ -1037,7 +1195,7 @@ func (b *Bridge) UpdateScene(id string, s *Scene) (*Response, error) {
 		return nil, err
 	}
 
-	res, err := put(url, data)
+	res, err := put(ctx, url, data)
 	if err != nil {
 		return nil, err
 	}
@@ -1058,6 +1216,12 @@ func (b *Bridge) UpdateScene(id string, s *Scene) (*Response, error) {
 // SetSceneLightState allows for setting the state of a light in a scene.
 // SetSceneLightState accepts the id of the scene, the id of a light associated with the scene and the state object.
 func (b *Bridge) SetSceneLightState(id string, iid int, l *State) (*Response, error) {
+	return b.SetSceneLightStateContext(context.Background(), id, iid, l)
+}
+
+// SetSceneLightStateContext allows for setting the state of a light in a scene.
+// SetSceneLightStateContext accepts the id of the scene, the id of a light associated with the scene and the state object.
+func (b *Bridge) SetSceneLightStateContext(ctx context.Context, id string, iid int, l *State) (*Response, error) {
 
 	var a []*APIResponse
 
@@ -1072,7 +1236,7 @@ func (b *Bridge) SetSceneLightState(id string, iid int, l *State) (*Response, er
 		return nil, err
 	}
 
-	res, err := put(url, data)
+	res, err := put(ctx, url, data)
 	if err != nil {
 		return nil, err
 	}
@@ -1092,6 +1256,11 @@ func (b *Bridge) SetSceneLightState(id string, iid int, l *State) (*Response, er
 
 // RecallScene will recall a scene in a group identified by both scene and group identifiers
 func (b *Bridge) RecallScene(id string, gid int) (*Response, error) {
+	return b.RecallSceneContext(context.Background(), id, gid)
+}
+
+// RecallSceneContext will recall a scene in a group identified by both scene and group identifiers
+func (b *Bridge) RecallSceneContext(ctx context.Context, id string, gid int) (*Response, error) {
 
 	var a []*APIResponse
 
@@ -1108,7 +1277,7 @@ func (b *Bridge) RecallScene(id string, gid int) (*Response, error) {
 		return nil, err
 	}
 
-	res, err := put(url, data)
+	res, err := put(ctx, url, data)
 	if err != nil {
 		return nil, err
 	}
@@ -1128,6 +1297,11 @@ func (b *Bridge) RecallScene(id string, gid int) (*Response, error) {
 
 // CreateScene creates one new scene with its attributes defined in s
 func (b *Bridge) CreateScene(s *Scene) (*Response, error) {
+	return b.CreateSceneContext(context.Background(), s)
+}
+
+// CreateSceneContext creates one new scene with its attributes defined in s
+func (b *Bridge) CreateSceneContext(ctx context.Context, s *Scene) (*Response, error) {
 
 	var a []*APIResponse
 
@@ -1141,7 +1315,7 @@ func (b *Bridge) CreateScene(s *Scene) (*Response, error) {
 		return nil, err
 	}
 
-	res, err := post(url, data)
+	res, err := post(ctx, url, data)
 	if err != nil {
 		return nil, err
 	}
@@ -1161,6 +1335,11 @@ func (b *Bridge) CreateScene(s *Scene) (*Response, error) {
 
 // DeleteScene deletes one scene from the bridge
 func (b *Bridge) DeleteScene(id string) error {
+	return b.DeleteSceneContext(context.Background(), id)
+}
+
+// DeleteSceneContext deletes one scene from the bridge
+func (b *Bridge) DeleteSceneContext(ctx context.Context, id string) error {
 
 	var a []*APIResponse
 
@@ -1169,7 +1348,7 @@ func (b *Bridge) DeleteScene(id string) error {
 		return err
 	}
 
-	res, err := delete(url)
+	res, err := delete(ctx, url)
 	if err != nil {
 		return err
 	}
@@ -1190,8 +1369,13 @@ func (b *Bridge) DeleteScene(id string) error {
 
 */
 
-// GetSchedules returns all scehdules known to the bridge
+// GetSchedules returns all schedules known to the bridge
 func (b *Bridge) GetSchedules() ([]*Schedule, error) {
+	return b.GetSchedulesContext(context.Background())
+}
+
+// GetSchedulesContext returns all schedules known to the bridge
+func (b *Bridge) GetSchedulesContext(ctx context.Context) ([]*Schedule, error) {
 
 	var r map[string]Schedule
 
@@ -1200,7 +1384,7 @@ func (b *Bridge) GetSchedules() ([]*Schedule, error) {
 		return nil, err
 	}
 
-	res, err := get(url)
+	res, err := get(ctx, url)
 	if err != nil {
 		return nil, err
 	}
@@ -1227,6 +1411,11 @@ func (b *Bridge) GetSchedules() ([]*Schedule, error) {
 
 // GetSchedule returns one schedule by id defined in i
 func (b *Bridge) GetSchedule(i int) (*Schedule, error) {
+	return b.GetScheduleContext(context.Background(), i)
+}
+
+// GetScheduleContext returns one schedule by id defined in i
+func (b *Bridge) GetScheduleContext(ctx context.Context, i int) (*Schedule, error) {
 
 	g := &Schedule{
 		ID: i,
@@ -1237,7 +1426,7 @@ func (b *Bridge) GetSchedule(i int) (*Schedule, error) {
 		return nil, err
 	}
 
-	res, err := get(url)
+	res, err := get(ctx, url)
 	if err != nil {
 		return nil, err
 	}
@@ -1253,6 +1442,11 @@ func (b *Bridge) GetSchedule(i int) (*Schedule, error) {
 
 // CreateSchedule creates one schedule and sets its attributes defined in s
 func (b *Bridge) CreateSchedule(s *Schedule) (*Response, error) {
+	return b.CreateScheduleContext(context.Background(), s)
+}
+
+// CreateScheduleContext creates one schedule and sets its attributes defined in s
+func (b *Bridge) CreateScheduleContext(ctx context.Context, s *Schedule) (*Response, error) {
 
 	var a []*APIResponse
 
@@ -1266,7 +1460,7 @@ func (b *Bridge) CreateSchedule(s *Schedule) (*Response, error) {
 		return nil, err
 	}
 
-	res, err := post(url, data)
+	res, err := post(ctx, url, data)
 	if err != nil {
 		return nil, err
 	}
@@ -1287,6 +1481,11 @@ func (b *Bridge) CreateSchedule(s *Schedule) (*Response, error) {
 
 // UpdateSchedule updates one schedule by its id of i and attributes by schedule
 func (b *Bridge) UpdateSchedule(i int, schedule *Schedule) (*Response, error) {
+	return b.UpdateScheduleContext(context.Background(), i, schedule)
+}
+
+// UpdateScheduleContext updates one schedule by its id of i and attributes by schedule
+func (b *Bridge) UpdateScheduleContext(ctx context.Context, i int, schedule *Schedule) (*Response, error) {
 
 	var a []*APIResponse
 
@@ -1300,7 +1499,7 @@ func (b *Bridge) UpdateSchedule(i int, schedule *Schedule) (*Response, error) {
 		return nil, err
 	}
 
-	res, err := put(url, data)
+	res, err := put(ctx, url, data)
 	if err != nil {
 		return nil, err
 	}
@@ -1320,6 +1519,11 @@ func (b *Bridge) UpdateSchedule(i int, schedule *Schedule) (*Response, error) {
 
 // DeleteSchedule deletes one schedule from the bridge by its id of i
 func (b *Bridge) DeleteSchedule(i int) error {
+	return b.DeleteScheduleContext(context.Background(), i)
+}
+
+// DeleteScheduleContext deletes one schedule from the bridge by its id of i
+func (b *Bridge) DeleteScheduleContext(ctx context.Context, i int) error {
 
 	var a []*APIResponse
 
@@ -1329,7 +1533,7 @@ func (b *Bridge) DeleteSchedule(i int) error {
 		return err
 	}
 
-	res, err := delete(url)
+	res, err := delete(ctx, url)
 	if err != nil {
 		return err
 	}
@@ -1352,6 +1556,11 @@ func (b *Bridge) DeleteSchedule(i int) error {
 
 // GetSensors returns all sensors known to the bridge
 func (b *Bridge) GetSensors() ([]Sensor, error) {
+	return b.GetSensorsContext(context.Background())
+}
+
+// GetSensorsContext returns all sensors known to the bridge
+func (b *Bridge) GetSensorsContext(ctx context.Context) ([]Sensor, error) {
 
 	s := map[string]Sensor{}
 
@@ -1360,7 +1569,7 @@ func (b *Bridge) GetSensors() ([]Sensor, error) {
 		return nil, err
 	}
 
-	res, err := get(url)
+	res, err := get(ctx, url)
 	if err != nil {
 		return nil, err
 	}
@@ -1384,6 +1593,11 @@ func (b *Bridge) GetSensors() ([]Sensor, error) {
 
 // GetSensor returns one sensor by its id of i
 func (b *Bridge) GetSensor(i int) (*Sensor, error) {
+	return b.GetSensorContext(context.Background(), i)
+}
+
+// GetSensorContext returns one sensor by its id of i
+func (b *Bridge) GetSensorContext(ctx context.Context, i int) (*Sensor, error) {
 
 	r := &Sensor{
 		ID: i,
@@ -1395,7 +1609,7 @@ func (b *Bridge) GetSensor(i int) (*Sensor, error) {
 		return nil, err
 	}
 
-	res, err := get(url)
+	res, err := get(ctx, url)
 	if err != nil {
 		return r, err
 	}
@@ -1411,6 +1625,11 @@ func (b *Bridge) GetSensor(i int) (*Sensor, error) {
 
 // CreateSensor creates one new sensor
 func (b *Bridge) CreateSensor(s *Sensor) (*Response, error) {
+	return b.CreateSensorContext(context.Background(), s)
+}
+
+// CreateSensorContext creates one new sensor
+func (b *Bridge) CreateSensorContext(ctx context.Context, s *Sensor) (*Response, error) {
 
 	var a []*APIResponse
 
@@ -1424,7 +1643,7 @@ func (b *Bridge) CreateSensor(s *Sensor) (*Response, error) {
 		return nil, err
 	}
 
-	res, err := post(url, data)
+	res, err := post(ctx, url, data)
 	if err != nil {
 		return nil, err
 	}
@@ -1446,6 +1665,12 @@ func (b *Bridge) CreateSensor(s *Sensor) (*Response, error) {
 // FindSensors starts a search for new sensors.
 // Use GetNewSensors() to verify if new sensors have been discovered in the bridge.
 func (b *Bridge) FindSensors() (*Response, error) {
+	return b.FindSensorsContext(context.Background())
+}
+
+// FindSensorsContext starts a search for new sensors.
+// Use GetNewSensorsContext() to verify if new sensors have been discovered in the bridge.
+func (b *Bridge) FindSensorsContext(ctx context.Context) (*Response, error) {
 
 	var a []*APIResponse
 
@@ -1454,7 +1679,7 @@ func (b *Bridge) FindSensors() (*Response, error) {
 		return nil, err
 	}
 
-	res, err := post(url, nil)
+	res, err := post(ctx, url, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1475,6 +1700,11 @@ func (b *Bridge) FindSensors() (*Response, error) {
 
 // GetNewSensors returns a list of sensors that were discovered last time GetNewSensors() was executed.
 func (b *Bridge) GetNewSensors() (*NewSensor, error) {
+	return b.GetNewSensorsContext(context.Background())
+}
+
+// GetNewSensorsContext returns a list of sensors that were discovered last time GetNewSensors() was executed.
+func (b *Bridge) GetNewSensorsContext(ctx context.Context) (*NewSensor, error) {
 
 	var n map[string]Sensor
 	var result *NewSensor
@@ -1484,7 +1714,7 @@ func (b *Bridge) GetNewSensors() (*NewSensor, error) {
 		return nil, err
 	}
 
-	res, err := get(url)
+	res, err := get(ctx, url)
 	if err != nil {
 		return nil, err
 	}
@@ -1517,6 +1747,11 @@ func (b *Bridge) GetNewSensors() (*NewSensor, error) {
 
 // UpdateSensor updates one sensor by its id and attributes by sensor
 func (b *Bridge) UpdateSensor(i int, sensor *Sensor) (*Response, error) {
+	return b.UpdateSensorContext(context.Background(), i, sensor)
+}
+
+// UpdateSensorContext updates one sensor by its id and attributes by sensor
+func (b *Bridge) UpdateSensorContext(ctx context.Context, i int, sensor *Sensor) (*Response, error) {
 
 	var a []*APIResponse
 
@@ -1530,7 +1765,7 @@ func (b *Bridge) UpdateSensor(i int, sensor *Sensor) (*Response, error) {
 		return nil, err
 	}
 
-	res, err := put(url, data)
+	res, err := put(ctx, url, data)
 	if err != nil {
 		return nil, err
 	}
@@ -1550,6 +1785,11 @@ func (b *Bridge) UpdateSensor(i int, sensor *Sensor) (*Response, error) {
 
 // DeleteSensor deletes one sensor from the bridge
 func (b *Bridge) DeleteSensor(i int) error {
+	return b.DeleteSensorContext(context.Background(), i)
+}
+
+// DeleteSensorContext deletes one sensor from the bridge
+func (b *Bridge) DeleteSensorContext(ctx context.Context, i int) error {
 
 	var a []*APIResponse
 
@@ -1559,7 +1799,7 @@ func (b *Bridge) DeleteSensor(i int) error {
 		return err
 	}
 
-	res, err := delete(url)
+	res, err := delete(ctx, url)
 	if err != nil {
 		return err
 	}
@@ -1576,6 +1816,11 @@ func (b *Bridge) DeleteSensor(i int) error {
 
 // UpdateSensorConfig updates the configuration of one sensor. The allowed configuration parameters depend on the sensor type
 func (b *Bridge) UpdateSensorConfig(i int, c interface{}) (*Response, error) {
+	return b.UpdateSensorConfigContext(context.Background(), i, c)
+}
+
+// UpdateSensorConfigContext updates the configuration of one sensor. The allowed configuration parameters depend on the sensor type
+func (b *Bridge) UpdateSensorConfigContext(ctx context.Context, i int, c interface{}) (*Response, error) {
 	var a []*APIResponse
 
 	data, err := json.Marshal(&c)
@@ -1588,7 +1833,7 @@ func (b *Bridge) UpdateSensorConfig(i int, c interface{}) (*Response, error) {
 		return nil, err
 	}
 
-	res, err := put(url, data)
+	res, err := put(ctx, url, data)
 	if err != nil {
 		return nil, err
 	}
@@ -1614,6 +1859,11 @@ func (b *Bridge) UpdateSensorConfig(i int, c interface{}) (*Response, error) {
 
 // GetCapabilities returns a list of capabilities of resources supported in the bridge.
 func (b *Bridge) GetCapabilities() (*Capabilities, error) {
+	return b.GetCapabilitiesContext(context.Background())
+}
+
+// GetCapabilitiesContext returns a list of capabilities of resources supported in the bridge.
+func (b *Bridge) GetCapabilitiesContext(ctx context.Context) (*Capabilities, error) {
 
 	s := &Capabilities{}
 
@@ -1622,7 +1872,7 @@ func (b *Bridge) GetCapabilities() (*Capabilities, error) {
 		return nil, err
 	}
 
-	res, err := get(url)
+	res, err := get(ctx, url)
 	if err != nil {
 		return nil, err
 	}

--- a/bridge.go
+++ b/bridge.go
@@ -49,11 +49,11 @@ func (b *Bridge) Login(u string) *Bridge {
 
 // GetConfig returns the bridge configuration
 func (b *Bridge) GetConfig() (*Config, error) {
-	return b.GetConfigWithContext(context.Background())
+	return b.GetConfigContext(context.Background())
 }
 
 // GetConfigContext returns the bridge configuration
-func (b *Bridge) GetConfigWithContext(ctx context.Context) (*Config, error) {
+func (b *Bridge) GetConfigContext(ctx context.Context) (*Config, error) {
 
 	var config *Config
 

--- a/capabilities_test.go
+++ b/capabilities_test.go
@@ -1,8 +1,9 @@
 package huego_test
 
 import (
-	"github.com/amimof/huego"
 	"testing"
+
+	"github.com/amimof/huego"
 )
 
 func TestGetCapabilities(t *testing.T) {

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,7 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/group.go
+++ b/group.go
@@ -1,5 +1,7 @@
 package huego
 
+import "context"
+
 // Group represents a bridge group https://developers.meethue.com/documentation/groups-api
 type Group struct {
 	Name       string      `json:"name,omitempty"`
@@ -14,7 +16,7 @@ type Group struct {
 }
 
 // GroupState defines the state on a group.
-// Can be used to control the state of all lights in a group rather than controlling them induvidually
+// Can be used to control the state of all lights in a group rather than controlling them individually
 type GroupState struct {
 	AllOn bool `json:"all_on,omitempty"`
 	AnyOn bool `json:"any_on,omitempty"`
@@ -22,7 +24,12 @@ type GroupState struct {
 
 // SetState sets the state of the group to s.
 func (g *Group) SetState(s State) error {
-	_, err := g.bridge.SetGroupState(g.ID, s)
+	return g.SetStateContext(context.Background(), s)
+}
+
+// SetStateContext sets the state of the group to s.
+func (g *Group) SetStateContext(ctx context.Context, s State) error {
+	_, err := g.bridge.SetGroupStateContext(ctx, g.ID, s)
 	if err != nil {
 		return err
 	}
@@ -32,8 +39,13 @@ func (g *Group) SetState(s State) error {
 
 // Rename sets the name property of the group
 func (g *Group) Rename(new string) error {
+	return g.RenameContext(context.Background(), new)
+}
+
+// RenameContext sets the name property of the group
+func (g *Group) RenameContext(ctx context.Context, new string) error {
 	update := Group{Name: new}
-	_, err := g.bridge.UpdateGroup(g.ID, update)
+	_, err := g.bridge.UpdateGroupContext(ctx, g.ID, update)
 	if err != nil {
 		return err
 	}
@@ -43,8 +55,13 @@ func (g *Group) Rename(new string) error {
 
 // Off sets the On state of one group to false, turning all lights in the group off
 func (g *Group) Off() error {
+	return g.OffContext(context.Background())
+}
+
+// OffContext sets the On state of one group to false, turning all lights in the group off
+func (g *Group) OffContext(ctx context.Context) error {
 	state := State{On: false}
-	_, err := g.bridge.SetGroupState(g.ID, state)
+	_, err := g.bridge.SetGroupStateContext(ctx, g.ID, state)
 	if err != nil {
 		return err
 	}
@@ -54,8 +71,13 @@ func (g *Group) Off() error {
 
 // On sets the On state of one group to true, turning all lights in the group on
 func (g *Group) On() error {
+	return g.OnContext(context.Background())
+}
+
+// OnContext sets the On state of one group to true, turning all lights in the group on
+func (g *Group) OnContext(ctx context.Context) error {
 	state := State{On: true}
-	_, err := g.bridge.SetGroupState(g.ID, state)
+	_, err := g.bridge.SetGroupStateContext(ctx, g.ID, state)
 	if err != nil {
 		return err
 	}
@@ -70,8 +92,13 @@ func (g *Group) IsOn() bool {
 
 // Bri sets the light brightness state property
 func (g *Group) Bri(new uint8) error {
+	return g.BriContext(context.Background(), new)
+}
+
+// BriContext sets the light brightness state property
+func (g *Group) BriContext(ctx context.Context, new uint8) error {
 	update := State{On: true, Bri: new}
-	_, err := g.bridge.SetGroupState(g.ID, update)
+	_, err := g.bridge.SetGroupStateContext(ctx, g.ID, update)
 	if err != nil {
 		return err
 	}
@@ -81,8 +108,13 @@ func (g *Group) Bri(new uint8) error {
 
 // Hue sets the light hue state property (0-65535)
 func (g *Group) Hue(new uint16) error {
+	return g.HueContext(context.Background(), new)
+}
+
+// HueContext sets the light hue state property (0-65535)
+func (g *Group) HueContext(ctx context.Context, new uint16) error {
 	update := State{On: true, Hue: new}
-	_, err := g.bridge.SetGroupState(g.ID, update)
+	_, err := g.bridge.SetGroupStateContext(ctx, g.ID, update)
 	if err != nil {
 		return err
 	}
@@ -92,8 +124,13 @@ func (g *Group) Hue(new uint16) error {
 
 // Sat sets the light saturation state property (0-254)
 func (g *Group) Sat(new uint8) error {
+	return g.SatContext(context.Background(), new)
+}
+
+// SatContext sets the light saturation state property (0-254)
+func (g *Group) SatContext(ctx context.Context, new uint8) error {
 	update := State{On: true, Sat: new}
-	_, err := g.bridge.SetGroupState(g.ID, update)
+	_, err := g.bridge.SetGroupStateContext(ctx, g.ID, update)
 	if err != nil {
 		return err
 	}
@@ -103,8 +140,13 @@ func (g *Group) Sat(new uint8) error {
 
 // Xy sets the x and y coordinates of a color in CIE color space. (0-1 per value)
 func (g *Group) Xy(new []float32) error {
+	return g.XyContext(context.Background(), new)
+}
+
+// XyContext sets the x and y coordinates of a color in CIE color space. (0-1 per value)
+func (g *Group) XyContext(ctx context.Context, new []float32) error {
 	update := State{On: true, Xy: new}
-	_, err := g.bridge.SetGroupState(g.ID, update)
+	_, err := g.bridge.SetGroupStateContext(ctx, g.ID, update)
 	if err != nil {
 		return err
 	}
@@ -114,8 +156,13 @@ func (g *Group) Xy(new []float32) error {
 
 // Ct sets the light color temperature state property
 func (g *Group) Ct(new uint16) error {
+	return g.CtContext(context.Background(), new)
+}
+
+// CtContext sets the light color temperature state property
+func (g *Group) CtContext(ctx context.Context, new uint16) error {
 	update := State{On: true, Ct: new}
-	_, err := g.bridge.SetGroupState(g.ID, update)
+	_, err := g.bridge.SetGroupStateContext(ctx, g.ID, update)
 	if err != nil {
 		return err
 	}
@@ -125,8 +172,13 @@ func (g *Group) Ct(new uint16) error {
 
 // Scene sets the scene by it's identifier of the scene you wish to recall
 func (g *Group) Scene(scene string) error {
+	return g.SceneContext(context.Background(), scene)
+}
+
+// SceneContext sets the scene by it's identifier of the scene you wish to recall
+func (g *Group) SceneContext(ctx context.Context, scene string) error {
 	update := State{On: true, Scene: scene}
-	_, err := g.bridge.SetGroupState(g.ID, update)
+	_, err := g.bridge.SetGroupStateContext(ctx, g.ID, update)
 	if err != nil {
 		return err
 	}
@@ -136,8 +188,13 @@ func (g *Group) Scene(scene string) error {
 
 // TransitionTime sets the duration of the transition from the light’s current state to the new state
 func (g *Group) TransitionTime(new uint16) error {
+	return g.TransitionTimeContext(context.Background(), new)
+}
+
+// TransitionTimeContext sets the duration of the transition from the light’s current state to the new state
+func (g *Group) TransitionTimeContext(ctx context.Context, new uint16) error {
 	update := State{On: g.State.On, TransitionTime: new}
-	_, err := g.bridge.SetGroupState(g.ID, update)
+	_, err := g.bridge.SetGroupStateContext(ctx, g.ID, update)
 	if err != nil {
 		return err
 	}
@@ -147,8 +204,13 @@ func (g *Group) TransitionTime(new uint16) error {
 
 // Effect the dynamic effect of the lights in the group, currently “none” and “colorloop” are supported
 func (g *Group) Effect(new string) error {
+	return g.EffectContext(context.Background(), new)
+}
+
+// EffectContext the dynamic effect of the lights in the group, currently “none” and “colorloop” are supported
+func (g *Group) EffectContext(ctx context.Context, new string) error {
 	update := State{On: true, Effect: new}
-	_, err := g.bridge.SetGroupState(g.ID, update)
+	_, err := g.bridge.SetGroupStateContext(ctx, g.ID, update)
 	if err != nil {
 		return err
 	}
@@ -161,8 +223,16 @@ func (g *Group) Effect(new string) error {
 // “select” – The light is performing one breathe cycle.
 // “lselect” – The light is performing breathe cycles for 15 seconds or until alert is set to "none".
 func (g *Group) Alert(new string) error {
+	return g.AlertContext(context.Background(), new)
+}
+
+// AlertContext makes the lights in the group blink in its current color. Supported values are:
+// “none” – The light is not performing an alert effect.
+// “select” – The light is performing one breathe cycle.
+// “lselect” – The light is performing breathe cycles for 15 seconds or until alert is set to "none".
+func (g *Group) AlertContext(ctx context.Context, new string) error {
 	update := State{On: true, Alert: new}
-	_, err := g.bridge.SetGroupState(g.ID, update)
+	_, err := g.bridge.SetGroupStateContext(ctx, g.ID, update)
 	if err != nil {
 		return err
 	}

--- a/huego.go
+++ b/huego.go
@@ -2,6 +2,7 @@
 package huego
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -79,12 +80,14 @@ func unmarshal(data []byte, v interface{}) error {
 	return nil
 }
 
-func get(url string) ([]byte, error) {
+func get(ctx context.Context, url string) ([]byte, error) {
 
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return nil, err
 	}
+
+	req = req.WithContext(ctx)
 
 	client := http.Client{}
 	res, err := client.Do(req)
@@ -103,7 +106,7 @@ func get(url string) ([]byte, error) {
 	return body, nil
 }
 
-func put(url string, data []byte) ([]byte, error) {
+func put(ctx context.Context, url string, data []byte) ([]byte, error) {
 
 	body := strings.NewReader(string(data))
 
@@ -112,6 +115,8 @@ func put(url string, data []byte) ([]byte, error) {
 		return nil, err
 	}
 
+	req = req.WithContext(ctx)
+
 	req.Header.Set("Content-Type", "application/json")
 
 	client := http.Client{}
@@ -131,7 +136,7 @@ func put(url string, data []byte) ([]byte, error) {
 
 }
 
-func post(url string, data []byte) ([]byte, error) {
+func post(ctx context.Context, url string, data []byte) ([]byte, error) {
 
 	body := strings.NewReader(string(data))
 
@@ -140,6 +145,8 @@ func post(url string, data []byte) ([]byte, error) {
 		return nil, err
 	}
 
+	req = req.WithContext(ctx)
+
 	req.Header.Set("Content-Type", "application/json")
 
 	client := http.Client{}
@@ -159,12 +166,14 @@ func post(url string, data []byte) ([]byte, error) {
 
 }
 
-func delete(url string) ([]byte, error) {
+func delete(ctx context.Context, url string) ([]byte, error) {
 
 	req, err := http.NewRequest("DELETE", url, nil)
 	if err != nil {
 		return nil, err
 	}
+
+	req = req.WithContext(ctx)
 
 	req.Header.Set("Content-Type", "application/json")
 
@@ -188,11 +197,19 @@ func delete(url string) ([]byte, error) {
 // DiscoverAll performs a discovery on the network looking for bridges using https://www.meethue.com/api/nupnp service.
 // DiscoverAll returns a list of Bridge objects.
 func DiscoverAll() ([]Bridge, error) {
+	return DiscoverAllContext(context.Background())
+}
+
+// DiscoverAllContext performs a discovery on the network looking for bridges using https://www.meethue.com/api/nupnp service.
+// DiscoverAllContext returns a list of Bridge objects.
+func DiscoverAllContext(ctx context.Context) ([]Bridge, error) {
 
 	req, err := http.NewRequest("GET", "https://discovery.meethue.com", nil)
 	if err != nil {
 		return nil, err
 	}
+
+	req = req.WithContext(ctx)
 
 	client := http.Client{}
 	res, err := client.Do(req)
@@ -221,10 +238,16 @@ func DiscoverAll() ([]Bridge, error) {
 // Discover performs a discovery on the network looking for bridges using https://www.meethue.com/api/nupnp service.
 // Discover uses DiscoverAll() but only returns the first instance in the array of bridges if any.
 func Discover() (*Bridge, error) {
+	return DiscoverContext(context.Background())
+}
+
+// DiscoverContext performs a discovery on the network looking for bridges using https://www.meethue.com/api/nupnp service.
+// DiscoverContext uses DiscoverAllContext() but only returns the first instance in the array of bridges if any.
+func DiscoverContext(ctx context.Context) (*Bridge, error) {
 
 	b := &Bridge{}
 
-	bridges, err := DiscoverAll()
+	bridges, err := DiscoverAllContext(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/light.go
+++ b/light.go
@@ -1,5 +1,7 @@
 package huego
 
+import "context"
+
 // Light represents a bridge light https://developers.meethue.com/documentation/lights-api
 type Light struct {
 	State            *State `json:"state,omitempty"`
@@ -45,7 +47,12 @@ type NewLight struct {
 
 // SetState sets the state of the light to s.
 func (l *Light) SetState(s State) error {
-	_, err := l.bridge.SetLightState(l.ID, s)
+	return l.SetStateContext(context.Background(), s)
+}
+
+// SetStateContext sets the state of the light to s.
+func (l *Light) SetStateContext(ctx context.Context, s State) error {
+	_, err := l.bridge.SetLightStateContext(ctx, l.ID, s)
 	if err != nil {
 		return err
 	}
@@ -55,8 +62,13 @@ func (l *Light) SetState(s State) error {
 
 // Off sets the On state of one light to false, turning it off
 func (l *Light) Off() error {
+	return l.OffContext(context.Background())
+}
+
+// OffContext sets the On state of one light to false, turning it off
+func (l *Light) OffContext(ctx context.Context) error {
 	state := State{On: false}
-	_, err := l.bridge.SetLightState(l.ID, state)
+	_, err := l.bridge.SetLightStateContext(ctx, l.ID, state)
 	if err != nil {
 		return err
 	}
@@ -66,8 +78,13 @@ func (l *Light) Off() error {
 
 // On sets the On state of one light to true, turning it on
 func (l *Light) On() error {
+	return l.OnContext(context.Background())
+}
+
+// OnContext sets the On state of one light to true, turning it on
+func (l *Light) OnContext(ctx context.Context) error {
 	state := State{On: true}
-	_, err := l.bridge.SetLightState(l.ID, state)
+	_, err := l.bridge.SetLightStateContext(ctx, l.ID, state)
 	if err != nil {
 		return err
 	}
@@ -82,8 +99,13 @@ func (l *Light) IsOn() bool {
 
 // Rename sets the name property of the light
 func (l *Light) Rename(new string) error {
+	return l.RenameContext(context.Background(), new)
+}
+
+// RenameContext sets the name property of the light
+func (l *Light) RenameContext(ctx context.Context, new string) error {
 	update := Light{Name: new}
-	_, err := l.bridge.UpdateLight(l.ID, update)
+	_, err := l.bridge.UpdateLightContext(ctx, l.ID, update)
 	if err != nil {
 		return err
 	}
@@ -93,8 +115,13 @@ func (l *Light) Rename(new string) error {
 
 // Bri sets the light brightness state property
 func (l *Light) Bri(new uint8) error {
+	return l.BriContext(context.Background(), new)
+}
+
+// BriContext sets the light brightness state property
+func (l *Light) BriContext(ctx context.Context, new uint8) error {
 	update := State{On: true, Bri: new}
-	_, err := l.bridge.SetLightState(l.ID, update)
+	_, err := l.bridge.SetLightStateContext(ctx, l.ID, update)
 	if err != nil {
 		return err
 	}
@@ -104,8 +131,13 @@ func (l *Light) Bri(new uint8) error {
 
 // Hue sets the light hue state property (0-65535)
 func (l *Light) Hue(new uint16) error {
+	return l.HueContext(context.Background(), new)
+}
+
+// HueContext sets the light hue state property (0-65535)
+func (l *Light) HueContext(ctx context.Context, new uint16) error {
 	update := State{On: true, Hue: new}
-	_, err := l.bridge.SetLightState(l.ID, update)
+	_, err := l.bridge.SetLightStateContext(ctx, l.ID, update)
 	if err != nil {
 		return err
 	}
@@ -115,8 +147,13 @@ func (l *Light) Hue(new uint16) error {
 
 // Sat sets the light saturation state property (0-254)
 func (l *Light) Sat(new uint8) error {
+	return l.SatContext(context.Background(), new)
+}
+
+// SatContext sets the light saturation state property (0-254)
+func (l *Light) SatContext(ctx context.Context, new uint8) error {
 	update := State{On: true, Sat: new}
-	_, err := l.bridge.SetLightState(l.ID, update)
+	_, err := l.bridge.SetLightStateContext(ctx, l.ID, update)
 	if err != nil {
 		return err
 	}
@@ -126,8 +163,13 @@ func (l *Light) Sat(new uint8) error {
 
 // Xy sets the x and y coordinates of a color in CIE color space. (0-1 per value)
 func (l *Light) Xy(new []float32) error {
+	return l.XyContext(context.Background(), new)
+}
+
+// XyContext sets the x and y coordinates of a color in CIE color space. (0-1 per value)
+func (l *Light) XyContext(ctx context.Context, new []float32) error {
 	update := State{On: true, Xy: new}
-	_, err := l.bridge.SetLightState(l.ID, update)
+	_, err := l.bridge.SetLightStateContext(ctx, l.ID, update)
 	if err != nil {
 		return err
 	}
@@ -137,8 +179,13 @@ func (l *Light) Xy(new []float32) error {
 
 // Ct sets the light color temperature state property
 func (l *Light) Ct(new uint16) error {
+	return l.CtContext(context.Background(), new)
+}
+
+// CtContext sets the light color temperature state property
+func (l *Light) CtContext(ctx context.Context, new uint16) error {
 	update := State{On: true, Ct: new}
-	_, err := l.bridge.SetLightState(l.ID, update)
+	_, err := l.bridge.SetLightStateContext(ctx, l.ID, update)
 	if err != nil {
 		return err
 	}
@@ -148,8 +195,13 @@ func (l *Light) Ct(new uint16) error {
 
 // TransitionTime sets the duration of the transition from the light’s current state to the new state
 func (l *Light) TransitionTime(new uint16) error {
+	return l.TransitionTimeContext(context.Background(), new)
+}
+
+// TransitionTimeContext sets the duration of the transition from the light’s current state to the new state
+func (l *Light) TransitionTimeContext(ctx context.Context, new uint16) error {
 	update := State{On: l.State.On, TransitionTime: new}
-	_, err := l.bridge.SetLightState(l.ID, update)
+	_, err := l.bridge.SetLightStateContext(ctx, l.ID, update)
 	if err != nil {
 		return err
 	}
@@ -159,8 +211,13 @@ func (l *Light) TransitionTime(new uint16) error {
 
 // Effect the dynamic effect of the light, currently “none” and “colorloop” are supported
 func (l *Light) Effect(new string) error {
+	return l.EffectContext(context.Background(), new)
+}
+
+// EffectContext the dynamic effect of the light, currently “none” and “colorloop” are supported
+func (l *Light) EffectContext(ctx context.Context, new string) error {
 	update := State{On: true, Effect: new}
-	_, err := l.bridge.SetLightState(l.ID, update)
+	_, err := l.bridge.SetLightStateContext(ctx, l.ID, update)
 	if err != nil {
 		return err
 	}
@@ -173,8 +230,16 @@ func (l *Light) Effect(new string) error {
 // “select” – The light is performing one breathe cycle.
 // “lselect” – The light is performing breathe cycles for 15 seconds or until alert is set to "none".
 func (l *Light) Alert(new string) error {
+	return l.AlertContext(context.Background(), new)
+}
+
+// AlertContext makes the light blink in its current color. Supported values are:
+// “none” – The light is not performing an alert effect.
+// “select” – The light is performing one breathe cycle.
+// “lselect” – The light is performing breathe cycles for 15 seconds or until alert is set to "none".
+func (l *Light) AlertContext(ctx context.Context, new string) error {
 	update := State{On: true, Alert: new}
-	_, err := l.bridge.SetLightState(l.ID, update)
+	_, err := l.bridge.SetLightStateContext(ctx, l.ID, update)
 	if err != nil {
 		return err
 	}

--- a/scene.go
+++ b/scene.go
@@ -1,5 +1,7 @@
 package huego
 
+import "context"
+
 // Scene represents a bridge scene https://developers.meethue.com/documentation/scenes-api
 type Scene struct {
 	Name            string        `json:"name,omitempty"`
@@ -21,7 +23,12 @@ type Scene struct {
 
 // Recall will recall the scene in the group identified by id
 func (s *Scene) Recall(id int) error {
-	_, err := s.bridge.RecallScene(s.ID, id)
+	return s.RecallContext(context.Background(), id)
+}
+
+// RecallContext will recall the scene in the group identified by id
+func (s *Scene) RecallContext(ctx context.Context, id int) error {
+	_, err := s.bridge.RecallSceneContext(ctx, s.ID, id)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This closes #8 while keeping backwards compatibility with the existing API.

I took the liberty of correcting a few spelling errors in the process, but added them to the same commit, hope that's ok.