### PR TITLE
Add Type and Group fields to Scene structure.

### DIFF
--- a/huego_test.go
+++ b/huego_test.go
@@ -140,12 +140,12 @@ func init() {
 		{
 			method: "GET",
 			path:   "/scenes",
-			data:   `{"4e1c6b20e-on-0":{"name":"Kathyon1449133269486","lights":["2","3"],"owner":"ffffffffe0341b1b376a2389376a2389","recycle":true,"locked":false,"appdata":{},"picture":"","lastupdated":"2015-12-03T08:57:13","version":1},"3T2SvsxvwteNNys":{"name":"Cozydinner","lights":["1","2"],"owner":"ffffffffe0341b1b376a2389376a2389","recycle":true,"locked":false,"appdata":{"version":1,"data":"myAppData"},"picture":"","lastupdated":"2015-12-03T10:09:22","version":2}}`,
+			data:   `{"4e1c6b20e-on-0":{"name":"Kathyon1449133269486","lights":["2","3"],"owner":"ffffffffe0341b1b376a2389376a2389","recycle":true,"locked":false,"appdata":{},"picture":"","lastupdated":"2015-12-03T08:57:13","version":1},"3T2SvsxvwteNNys":{"name":"Cozydinner","type":"GroupScene","group":"1","lights":["1","2"],"owner":"ffffffffe0341b1b376a2389376a2389","recycle":true,"locked":false,"appdata":{"version":1,"data":"myAppData"},"picture":"","lastupdated":"2015-12-03T10:09:22","version":2}}`,
 		},
 		{
 			method: "GET",
 			path:   "/scenes/4e1c6b20e-on-0",
-			data:   `{"name":"Cozy dinner","lights":["1"],"owner":"newdeveloper","recycle":true,"locked":false,"appdata":{},"picture":"","lastupdated":"2015-12-03T10:09:22","version":2,"lightstates":{"1":{"on":true,"bri":237,"xy":[0.5806,0.3903]}}}`,
+			data:   `{"name":"Cozy dinner","type":"GroupScene","group":"1","lights":["1"],"owner":"newdeveloper","recycle":true,"locked":false,"appdata":{},"picture":"","lastupdated":"2015-12-03T10:09:22","version":2,"lightstates":{"1":{"on":true,"bri":237,"xy":[0.5806,0.3903]}}}`,
 		},
 		{
 			method: "POST",

--- a/scene.go
+++ b/scene.go
@@ -3,6 +3,8 @@ package huego
 // Scene represents a bridge scene https://developers.meethue.com/documentation/scenes-api
 type Scene struct {
 	Name            string        `json:"name,omitempty"`
+	Type            string        `json:"type,omitempty"`
+	Group           string        `json:"group,omitempty"`
 	Lights          []string      `json:"lights,omitempty"`
 	Owner           string        `json:"owner,omitempty"`
 	Recycle         bool          `json:"recycle,omitempty"`

--- a/scene_test.go
+++ b/scene_test.go
@@ -17,6 +17,8 @@ func TestGetScenes(t *testing.T) {
 	for i, scene := range scenes {
 		t.Logf("%d", i)
 		t.Logf("  Name: %s", scene.Name)
+		t.Logf("  Type: %s", scene.Type)
+		t.Logf("  Group: %s", scene.Group)
 		t.Logf("  Lights: %s", scene.Lights)
 		t.Logf("  Owner: %s", scene.Owner)
 		t.Logf("  Recycle: %t", scene.Recycle)
@@ -50,6 +52,8 @@ func TestGetScene(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Logf("  Name: %s", s.Name)
+	t.Logf("  Type: %s", s.Type)
+	t.Logf("  Group: %s", s.Group)
 	t.Logf("  Lights: %s", s.Lights)
 	t.Logf("  Owner: %s", s.Owner)
 	t.Logf("  Recycle: %t", s.Recycle)


### PR DESCRIPTION
The Scenes API now returns a "group" and "type" field. Those fields were absent from the huego Scene structure. This pull request adds them.

Check out the docs here: https://developers.meethue.com/develop/hue-api/4-scenes/#get-all-scenes