### PR TITLE
Remove Go `1.11` and add >`1.13` in Travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,10 @@ os: linux
 dist: xenial
 language: go
 go:
-  - 1.11.x
   - 1.12.x
   - 1.13.x
+  - 1.14.x
+  - 1.15.x
 script: 
 - make checkfmt
 - make fmt  


### PR DESCRIPTION
* Removes builds with Go 1.11
* Adds builds with Go 1.14
* Adds builds with Go 1.15