### PR TITLE
Use default http client

### DIFF
--- a/huego.go
+++ b/huego.go
@@ -94,7 +94,7 @@ func get(ctx context.Context, url string) ([]byte, error) {
 
 	req = req.WithContext(ctx)
 
-	client := http.Client{}
+	client := http.DefaultClient
 	res, err := client.Do(req)
 	if err != nil {
 		return nil, err
@@ -124,7 +124,7 @@ func put(ctx context.Context, url string, data []byte) ([]byte, error) {
 
 	req.Header.Set(contentType, applicationJSON)
 
-	client := http.Client{}
+	client := http.DefaultClient
 	res, err := client.Do(req)
 	if err != nil {
 		return nil, err
@@ -154,7 +154,7 @@ func post(ctx context.Context, url string, data []byte) ([]byte, error) {
 
 	req.Header.Set(contentType, applicationJSON)
 
-	client := http.Client{}
+	client := http.DefaultClient
 	res, err := client.Do(req)
 	if err != nil {
 		return nil, err
@@ -182,7 +182,7 @@ func delete(ctx context.Context, url string) ([]byte, error) {
 
 	req.Header.Set(contentType, applicationJSON)
 
-	client := http.Client{}
+	client := http.DefaultClient
 	res, err := client.Do(req)
 	if err != nil {
 		return nil, err
@@ -216,7 +216,7 @@ func DiscoverAllContext(ctx context.Context) ([]Bridge, error) {
 
 	req = req.WithContext(ctx)
 
-	client := http.Client{}
+	client := http.DefaultClient
 	res, err := client.Do(req)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
I think it's useful to use the default client here, it allows us to instrument our own client if need be. This is just the simplest way to accomplish this. Ideally I would like to pass this in via a struct type field, but didn't wanna deal with the refactor overhead of that.