### PR TITLE
Remove omitempty from Scene.Recycle

### DIFF
--- a/scene.go
+++ b/scene.go
@@ -9,7 +9,7 @@ type Scene struct {
 	Group           string        `json:"group,omitempty"`
 	Lights          []string      `json:"lights,omitempty"`
 	Owner           string        `json:"owner,omitempty"`
-	Recycle         bool          `json:"recycle,omitempty"`
+	Recycle         bool          `json:"recycle"`
 	Locked          bool          `json:"locked,omitempty"`
 	AppData         interface{}   `json:"appdata,omitempty"`
 	Picture         string        `json:"picture,omitempty"`


### PR DESCRIPTION
Even though the doc states "Set to ‘false’ when omitted.", the bridge actually complains when trying to do just that:

```
[
	{
		"error": {
			"type": 5,
			"address": "/scenes/recycle",
			"description": "invalid/missing parameters in body"
		}
	}
]
```