### PR TITLE
Add TransitionTime to Scene struct

### DIFF
--- a/scene.go
+++ b/scene.go
@@ -17,6 +17,7 @@ type Scene struct {
 	Version         int           `json:"version,omitempty"`
 	StoreSceneState bool          `json:"storescenestate,omitempty"`
 	LightStates     map[int]State `json:"lightstates,omitempty"`
+	TransitionTime  uint16        `json:"transitiontime,omitempty"`
 	ID              string        `json:"-"`
 	bridge          *Bridge
 }


### PR DESCRIPTION
To quote the docs:

> As of `1.36` transitiontime can be used in combination of “scene” attribute. This causes it to be recalled with the given transition time. If used in combination with multiple attributes, transitiontime is applied to all attributes supporting it (on, bri, xy, hue, sat, ct, scene)