### PR TITLE
Rename Scene.StoreSceneState to correct Scene.StoreLightState

### DIFF
--- a/scene.go
+++ b/scene.go
@@ -15,7 +15,7 @@ type Scene struct {
 	Picture         string        `json:"picture,omitempty"`
 	LastUpdated     string        `json:"lastupdated,omitempty"`
 	Version         int           `json:"version,omitempty"`
-	StoreSceneState bool          `json:"storescenestate,omitempty"`
+	StoreLightState bool          `json:"storelightstate,omitempty"`
 	LightStates     map[int]State `json:"lightstates,omitempty"`
 	ID              string        `json:"-"`
 	bridge          *Bridge


### PR DESCRIPTION
`storescenestate` is not a valid parameter, a quick google search only brings up this github repo, no other uses. It's called `storelightstate`.