### PR TITLE
Improve Scene struct

### DIFF
--- a/scene.go
+++ b/scene.go
@@ -15,7 +15,7 @@ type Scene struct {
 	Picture         string        `json:"picture,omitempty"`
 	LastUpdated     string        `json:"lastupdated,omitempty"`
 	Version         int           `json:"version,omitempty"`
-	StoreSceneState bool          `json:"storescenestate,omitempty"`
+	StoreLightState bool          `json:"storelightstate,omitempty"`
 	LightStates     map[int]State `json:"lightstates,omitempty"`
 	TransitionTime  uint16        `json:"transitiontime,omitempty"`
 	ID              string        `json:"-"`

--- a/scene.go
+++ b/scene.go
@@ -9,7 +9,7 @@ type Scene struct {
 	Group           string        `json:"group,omitempty"`
 	Lights          []string      `json:"lights,omitempty"`
 	Owner           string        `json:"owner,omitempty"`
-	Recycle         bool          `json:"recycle,omitempty"`
+	Recycle         bool          `json:"recycle"`
 	Locked          bool          `json:"locked,omitempty"`
 	AppData         interface{}   `json:"appdata,omitempty"`
 	Picture         string        `json:"picture,omitempty"`

--- a/scene.go
+++ b/scene.go
@@ -17,6 +17,7 @@ type Scene struct {
 	Version         int           `json:"version,omitempty"`
 	StoreSceneState bool          `json:"storescenestate,omitempty"`
 	LightStates     map[int]State `json:"lightstates,omitempty"`
+	TransitionTime  uint16        `json:"transitiontime,omitempty"`
 	ID              string        `json:"-"`
 	bridge          *Bridge
 }

--- a/scene_test.go
+++ b/scene_test.go
@@ -25,7 +25,7 @@ func TestGetScenes(t *testing.T) {
 		t.Logf("  Picture: %s", scene.Picture)
 		t.Logf("  LastUpdated: %s", scene.LastUpdated)
 		t.Logf("  Version: %d", scene.Version)
-		t.Logf("  StoreSceneState: %t", scene.StoreSceneState)
+		t.Logf("  StoreLightState: %t", scene.StoreLightState)
 		t.Logf("  ID: %s", scene.ID)
 	}
 
@@ -65,7 +65,7 @@ func TestGetScene(t *testing.T) {
 	t.Logf("  Picture: %s", s.Picture)
 	t.Logf("  LastUpdated: %s", s.LastUpdated)
 	t.Logf("  Version: %d", s.Version)
-	t.Logf("  StoreSceneState: %t", s.StoreSceneState)
+	t.Logf("  StoreLightState: %t", s.StoreLightState)
 	t.Logf("  ID: %s", s.ID)
 	t.Logf("  LightStates: %d", len(s.LightStates))
 	for k := range s.LightStates {


### PR DESCRIPTION
Fixes various issues with the `Scene` struct:

1. Remove omitempty from Recycle. Even though the doc states "Set to ‘false’ when omitted.", the bridge actually complains when trying to omit it:

```
[
	{
		"error": {
			"type": 5,
			"address": "/scenes/recycle",
			"description": "invalid/missing parameters in body"
		}
	}
]
```

---

2. Add TransitionTime to Scene struct. To quote the docs:

> As of `1.36` transitiontime can be used in combination of “scene” attribute. This causes it to be recalled with the given transition time. If used in combination with multiple attributes, transitiontime is applied to all attributes supporting it (on, bri, xy, hue, sat, ct, scene)

---

3. Rename Scene.StoreSceneState to correct Scene.StoreLightState

`storescenestate` is not a valid parameter, a quick google search only brings up this github repo, no other uses. It's called `storelightstate`.

---

(Sorry for the numerous pull requests, I think it's better to have it all in one)