### PR TITLE
Correct Lights API schema, ProductId to ProductName

### DIFF
--- a/light.go
+++ b/light.go
@@ -16,7 +16,7 @@ type Light struct {
 	UniqueID         string `json:"uniqueid,omitempty"`
 	SwVersion        string `json:"swversion,omitempty"`
 	SwConfigID       string `json:"swconfigid,omitempty"`
-	ProductID        string `json:"productid,omitempty"`
+	ProductName      string `json:"productname,omitempty"`
 	ID               int    `json:"-"`
 	bridge           *Bridge
 }

--- a/light_test.go
+++ b/light_test.go
@@ -23,7 +23,7 @@ func TestGetLights(t *testing.T) {
 		t.Logf("  UniqueID: %s", l.UniqueID)
 		t.Logf("  SwVersion: %s", l.SwVersion)
 		t.Logf("  SwConfigID: %s", l.SwConfigID)
-		t.Logf("  ProductID: %s", l.ProductID)
+		t.Logf("  ProductName: %s", l.ProductName)
 	}
 	contains := func(name string, ss []Light) bool {
 		for _, s := range ss {
@@ -56,7 +56,7 @@ func TestGetLight(t *testing.T) {
 		t.Logf("UniqueID: %s", l.UniqueID)
 		t.Logf("SwVersion: %s", l.SwVersion)
 		t.Logf("SwConfigID: %s", l.SwConfigID)
-		t.Logf("ProductID: %s", l.ProductID)
+		t.Logf("ProductName: %s", l.ProductName)
 		t.Logf("State:")
 		t.Logf("  On: %t", l.State.On)
 		t.Logf("  Bri: %d", l.State.Bri)


### PR DESCRIPTION
Lights API doesn't have 'productid' value, instead 'productname' should be there.

Ref. https://developers.meethue.com/develop/hue-api/lights-api/