### PR TITLE
Adds method that allows to identify a light optically

### DIFF
--- a/bridge.go
+++ b/bridge.go
@@ -571,6 +571,39 @@ func (b *Bridge) GetLightContext(ctx context.Context, i int) (*Light, error) {
 	return light, nil
 }
 
+// IdentifyLight allows identifying a light
+func (b *Bridge) IdentifyLight(i int) (*Response, error) {
+	return b.IdentifyLightContext(context.Background(), i)
+}
+
+// IdentifyLightContext allows identifying a light
+func (b *Bridge) IdentifyLightContext(ctx context.Context, i int) (*Response, error) {
+
+	var a []*APIResponse
+
+	url, err := b.getAPIPath("/lights/", strconv.Itoa(i), "/state")
+	if err != nil {
+		return nil, err
+	}
+	res, err := put(ctx, url, []byte(`{"alert":"select"}`))
+	if err != nil {
+		return nil, err
+	}
+
+	err = unmarshal(res, &a)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := handleResponse(a)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+
+}
+
 // SetLightState allows for controlling one light's state
 func (b *Bridge) SetLightState(i int, l State) (*Response, error) {
 	return b.SetLightStateContext(context.Background(), i, l)

--- a/huego_test.go
+++ b/huego_test.go
@@ -95,6 +95,12 @@ func init() {
 			data:   `[{"success":{"/lights/1/state/bri":200}},{"success":{"/lights/1/state/on":true}},{"success":{"/lights/1/state/hue":50000}}]`,
 		},
 		{
+			// Second route for identifying light testing
+			method: "PUT",
+			path:   path.Join(username, "/lights/2/state"),
+			data:   `[{"success":{"/lights/2/state/alert":"select"}}]`,
+		},
+		{
 			method: "PUT",
 			path:   path.Join(username, "/lights/1"),
 			data:   `[{"success":{"/lights/1/name":"Bedroom Light"}}]`,

--- a/light_test.go
+++ b/light_test.go
@@ -82,6 +82,24 @@ func TestGetLight(t *testing.T) {
 
 }
 
+func TestIdentifyLight(t *testing.T) {
+	b := New(hostname, username)
+	id := 2
+	resp, err := b.IdentifyLight(id)
+	if err != nil {
+		t.Fatal(err)
+	} else {
+		t.Logf("Light %d identified", id)
+		for k, v := range resp.Success {
+			t.Logf("%v: %s", k, v)
+		}
+	}
+
+	b.Host = badHostname
+	_, err = b.IdentifyLight(id)
+	assert.NotNil(t, err)
+}
+
 func TestSetLight(t *testing.T) {
 	b := New(hostname, username)
 	id := 1


### PR DESCRIPTION
I noticed while experimenting with the library that the function to identify a light is missing. It is very similar to the SetLightState method, but unfortunately the functionality cannot be achieved through it. I think it's mainly because the State always has the "On" property set when serializing to a json object. 