### PR TITLE
Add custom http.Client support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@
 TODO.md
 
 test/
+
+# jetbrains
+.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.0.3
+* Added ability to use a custom http.Client
+
 ## 1.0.2
 * Improved test coverage
 * Use of `httpmock` in tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,5 @@
 # Changelog
 
-## 1.0.3
-* Added ability to use a custom http.Client
-
 ## 1.0.2
 * Improved test coverage
 * Use of `httpmock` in tests

--- a/bridge.go
+++ b/bridge.go
@@ -66,7 +66,7 @@ func (b *Bridge) GetConfigContext(ctx context.Context) (*Config, error) {
 		return nil, err
 	}
 
-	res, err := b.get(ctx, url)
+	res, err := get(ctx, url, b.client)
 	if err != nil {
 		return nil, err
 	}
@@ -136,7 +136,7 @@ func (b *Bridge) createUserWithContext(ctx context.Context, deviceType string, g
 		return nil, err
 	}
 
-	res, err := b.post(ctx, url, data)
+	res, err := post(ctx, url, data, b.client)
 	if err != nil {
 		return nil, err
 	}
@@ -194,7 +194,7 @@ func (b *Bridge) UpdateConfigContext(ctx context.Context, c *Config) (*Response,
 		return nil, err
 	}
 
-	res, err := b.put(ctx, url, data)
+	res, err := put(ctx, url, data, b.client)
 	if err != nil {
 		return nil, err
 	}
@@ -227,7 +227,7 @@ func (b *Bridge) DeleteUserContext(ctx context.Context, n string) error {
 		return err
 	}
 
-	res, err := b.delete(ctx, url)
+	res, err := del(ctx, url, b.client)
 	if err != nil {
 		return err
 	}
@@ -258,7 +258,7 @@ func (b *Bridge) GetFullStateContext(ctx context.Context) (map[string]interface{
 		return nil, err
 	}
 
-	res, err := b.get(ctx, url)
+	res, err := get(ctx, url, b.client)
 	if err != nil {
 		return nil, err
 	}
@@ -292,7 +292,7 @@ func (b *Bridge) GetGroupsContext(ctx context.Context) ([]Group, error) {
 		return nil, err
 	}
 
-	res, err := b.get(ctx, url)
+	res, err := get(ctx, url, b.client)
 	if err != nil {
 		return nil, err
 	}
@@ -334,7 +334,7 @@ func (b *Bridge) GetGroupContext(ctx context.Context, i int) (*Group, error) {
 		return nil, err
 	}
 
-	res, err := b.get(ctx, url)
+	res, err := get(ctx, url, b.client)
 	if err != nil {
 		return nil, err
 	}
@@ -370,7 +370,7 @@ func (b *Bridge) SetGroupStateContext(ctx context.Context, i int, l State) (*Res
 		return nil, err
 	}
 
-	res, err := b.put(ctx, url, data)
+	res, err := put(ctx, url, data, b.client)
 	if err != nil {
 		return nil, err
 	}
@@ -409,7 +409,7 @@ func (b *Bridge) UpdateGroupContext(ctx context.Context, i int, l Group) (*Respo
 		return nil, err
 	}
 
-	res, err := b.put(ctx, url, data)
+	res, err := put(ctx, url, data, b.client)
 	if err != nil {
 		return nil, err
 	}
@@ -447,7 +447,7 @@ func (b *Bridge) CreateGroupContext(ctx context.Context, g Group) (*Response, er
 		return nil, err
 	}
 
-	res, err := b.post(ctx, url, data)
+	res, err := post(ctx, url, data, b.client)
 	if err != nil {
 		return nil, err
 	}
@@ -481,7 +481,7 @@ func (b *Bridge) DeleteGroupContext(ctx context.Context, i int) error {
 		return err
 	}
 
-	res, err := b.delete(ctx, url)
+	res, err := del(ctx, url, b.client)
 	if err != nil {
 		return err
 	}
@@ -517,7 +517,7 @@ func (b *Bridge) GetLightsContext(ctx context.Context) ([]Light, error) {
 		return nil, err
 	}
 
-	res, err := b.get(ctx, url)
+	res, err := get(ctx, url, b.client)
 	if err != nil {
 		return nil, err
 	}
@@ -559,7 +559,7 @@ func (b *Bridge) GetLightContext(ctx context.Context, i int) (*Light, error) {
 		return nil, err
 	}
 
-	res, err := b.get(ctx, url)
+	res, err := get(ctx, url, b.client)
 	if err != nil {
 		return light, err
 	}
@@ -588,7 +588,7 @@ func (b *Bridge) IdentifyLightContext(ctx context.Context, i int) (*Response, er
 	if err != nil {
 		return nil, err
 	}
-	res, err := b.put(ctx, url, []byte(`{"alert":"select"}`))
+	res, err := put(ctx, url, []byte(`{"alert":"select"}`), b.client)
 	if err != nil {
 		return nil, err
 	}
@@ -629,7 +629,7 @@ func (b *Bridge) SetLightStateContext(ctx context.Context, i int, l State) (*Res
 	if err != nil {
 		return nil, err
 	}
-	res, err := b.put(ctx, url, data)
+	res, err := put(ctx, url, data, b.client)
 	if err != nil {
 		return nil, err
 	}
@@ -665,7 +665,7 @@ func (b *Bridge) FindLightsContext(ctx context.Context) (*Response, error) {
 		return nil, err
 	}
 
-	res, err := b.post(ctx, url, nil)
+	res, err := post(ctx, url, nil, b.client)
 	if err != nil {
 		return nil, err
 	}
@@ -699,7 +699,7 @@ func (b *Bridge) GetNewLightsContext(ctx context.Context) (*NewLight, error) {
 		return nil, err
 	}
 
-	res, err := b.get(ctx, url)
+	res, err := get(ctx, url, b.client)
 	if err != nil {
 		return nil, err
 	}
@@ -742,7 +742,7 @@ func (b *Bridge) DeleteLightContext(ctx context.Context, i int) error {
 		return err
 	}
 
-	res, err := b.delete(ctx, url)
+	res, err := del(ctx, url, b.client)
 	if err != nil {
 		return err
 	}
@@ -779,7 +779,7 @@ func (b *Bridge) UpdateLightContext(ctx context.Context, i int, light Light) (*R
 		return nil, err
 	}
 
-	res, err := b.put(ctx, url, data)
+	res, err := put(ctx, url, data, b.client)
 	if err != nil {
 		return nil, err
 	}
@@ -818,7 +818,7 @@ func (b *Bridge) GetResourcelinksContext(ctx context.Context) ([]*Resourcelink, 
 		return nil, err
 	}
 
-	res, err := b.get(ctx, url)
+	res, err := get(ctx, url, b.client)
 	if err != nil {
 		return nil, err
 	}
@@ -860,7 +860,7 @@ func (b *Bridge) GetResourcelinkContext(ctx context.Context, i int) (*Resourceli
 		return nil, err
 	}
 
-	res, err := b.get(ctx, url)
+	res, err := get(ctx, url, b.client)
 	if err != nil {
 		return nil, err
 	}
@@ -894,7 +894,7 @@ func (b *Bridge) CreateResourcelinkContext(ctx context.Context, s *Resourcelink)
 		return nil, err
 	}
 
-	res, err := b.post(ctx, url, data)
+	res, err := post(ctx, url, data, b.client)
 	if err != nil {
 		return nil, err
 	}
@@ -932,7 +932,7 @@ func (b *Bridge) UpdateResourcelinkContext(ctx context.Context, i int, resourcel
 		return nil, err
 	}
 
-	res, err := b.put(ctx, url, data)
+	res, err := put(ctx, url, data, b.client)
 	if err != nil {
 		return nil, err
 	}
@@ -966,7 +966,7 @@ func (b *Bridge) DeleteResourcelinkContext(ctx context.Context, i int) error {
 		return err
 	}
 
-	res, err := b.delete(ctx, url)
+	res, err := del(ctx, url, b.client)
 	if err != nil {
 		return err
 	}
@@ -1002,7 +1002,7 @@ func (b *Bridge) GetRulesContext(ctx context.Context) ([]*Rule, error) {
 		return nil, err
 	}
 
-	res, err := b.get(ctx, url)
+	res, err := get(ctx, url, b.client)
 	if err != nil {
 		return nil, err
 	}
@@ -1044,7 +1044,7 @@ func (b *Bridge) GetRuleContext(ctx context.Context, i int) (*Rule, error) {
 		return nil, err
 	}
 
-	res, err := b.get(ctx, url)
+	res, err := get(ctx, url, b.client)
 	if err != nil {
 		return nil, err
 	}
@@ -1078,7 +1078,7 @@ func (b *Bridge) CreateRuleContext(ctx context.Context, s *Rule) (*Response, err
 		return nil, err
 	}
 
-	res, err := b.post(ctx, url, data)
+	res, err := post(ctx, url, data, b.client)
 	if err != nil {
 		return nil, err
 	}
@@ -1117,7 +1117,7 @@ func (b *Bridge) UpdateRuleContext(ctx context.Context, i int, rule *Rule) (*Res
 		return nil, err
 	}
 
-	res, err := b.put(ctx, url, data)
+	res, err := put(ctx, url, data, b.client)
 	if err != nil {
 		return nil, err
 	}
@@ -1151,7 +1151,7 @@ func (b *Bridge) DeleteRuleContext(ctx context.Context, i int) error {
 		return err
 	}
 
-	res, err := b.delete(ctx, url)
+	res, err := del(ctx, url, b.client)
 	if err != nil {
 		return err
 	}
@@ -1187,7 +1187,7 @@ func (b *Bridge) GetScenesContext(ctx context.Context) ([]Scene, error) {
 		return nil, err
 	}
 
-	res, err := b.get(ctx, url)
+	res, err := get(ctx, url, b.client)
 	if err != nil {
 		return nil, err
 	}
@@ -1223,7 +1223,7 @@ func (b *Bridge) GetSceneContext(ctx context.Context, i string) (*Scene, error) 
 		return nil, err
 	}
 
-	res, err := b.get(ctx, url)
+	res, err := get(ctx, url, b.client)
 	if err != nil {
 		return nil, err
 	}
@@ -1263,7 +1263,7 @@ func (b *Bridge) UpdateSceneContext(ctx context.Context, id string, s *Scene) (*
 		return nil, err
 	}
 
-	res, err := b.put(ctx, url, data)
+	res, err := put(ctx, url, data, b.client)
 	if err != nil {
 		return nil, err
 	}
@@ -1304,7 +1304,7 @@ func (b *Bridge) SetSceneLightStateContext(ctx context.Context, id string, iid i
 		return nil, err
 	}
 
-	res, err := b.put(ctx, url, data)
+	res, err := put(ctx, url, data, b.client)
 	if err != nil {
 		return nil, err
 	}
@@ -1345,7 +1345,7 @@ func (b *Bridge) RecallSceneContext(ctx context.Context, id string, gid int) (*R
 		return nil, err
 	}
 
-	res, err := b.put(ctx, url, data)
+	res, err := put(ctx, url, data, b.client)
 	if err != nil {
 		return nil, err
 	}
@@ -1383,7 +1383,7 @@ func (b *Bridge) CreateSceneContext(ctx context.Context, s *Scene) (*Response, e
 		return nil, err
 	}
 
-	res, err := b.post(ctx, url, data)
+	res, err := post(ctx, url, data, b.client)
 	if err != nil {
 		return nil, err
 	}
@@ -1416,7 +1416,7 @@ func (b *Bridge) DeleteSceneContext(ctx context.Context, id string) error {
 		return err
 	}
 
-	res, err := b.delete(ctx, url)
+	res, err := del(ctx, url, b.client)
 	if err != nil {
 		return err
 	}
@@ -1452,7 +1452,7 @@ func (b *Bridge) GetSchedulesContext(ctx context.Context) ([]*Schedule, error) {
 		return nil, err
 	}
 
-	res, err := b.get(ctx, url)
+	res, err := get(ctx, url, b.client)
 	if err != nil {
 		return nil, err
 	}
@@ -1494,7 +1494,7 @@ func (b *Bridge) GetScheduleContext(ctx context.Context, i int) (*Schedule, erro
 		return nil, err
 	}
 
-	res, err := b.get(ctx, url)
+	res, err := get(ctx, url, b.client)
 	if err != nil {
 		return nil, err
 	}
@@ -1528,7 +1528,7 @@ func (b *Bridge) CreateScheduleContext(ctx context.Context, s *Schedule) (*Respo
 		return nil, err
 	}
 
-	res, err := b.post(ctx, url, data)
+	res, err := post(ctx, url, data, b.client)
 	if err != nil {
 		return nil, err
 	}
@@ -1567,7 +1567,7 @@ func (b *Bridge) UpdateScheduleContext(ctx context.Context, i int, schedule *Sch
 		return nil, err
 	}
 
-	res, err := b.put(ctx, url, data)
+	res, err := put(ctx, url, data, b.client)
 	if err != nil {
 		return nil, err
 	}
@@ -1601,7 +1601,7 @@ func (b *Bridge) DeleteScheduleContext(ctx context.Context, i int) error {
 		return err
 	}
 
-	res, err := b.delete(ctx, url)
+	res, err := del(ctx, url, b.client)
 	if err != nil {
 		return err
 	}
@@ -1637,7 +1637,7 @@ func (b *Bridge) GetSensorsContext(ctx context.Context) ([]Sensor, error) {
 		return nil, err
 	}
 
-	res, err := b.get(ctx, url)
+	res, err := get(ctx, url, b.client)
 	if err != nil {
 		return nil, err
 	}
@@ -1677,7 +1677,7 @@ func (b *Bridge) GetSensorContext(ctx context.Context, i int) (*Sensor, error) {
 		return nil, err
 	}
 
-	res, err := b.get(ctx, url)
+	res, err := get(ctx, url, b.client)
 	if err != nil {
 		return r, err
 	}
@@ -1711,7 +1711,7 @@ func (b *Bridge) CreateSensorContext(ctx context.Context, s *Sensor) (*Response,
 		return nil, err
 	}
 
-	res, err := b.post(ctx, url, data)
+	res, err := post(ctx, url, data, b.client)
 	if err != nil {
 		return nil, err
 	}
@@ -1747,7 +1747,7 @@ func (b *Bridge) FindSensorsContext(ctx context.Context) (*Response, error) {
 		return nil, err
 	}
 
-	res, err := b.post(ctx, url, nil)
+	res, err := post(ctx, url, nil, b.client)
 	if err != nil {
 		return nil, err
 	}
@@ -1782,7 +1782,7 @@ func (b *Bridge) GetNewSensorsContext(ctx context.Context) (*NewSensor, error) {
 		return nil, err
 	}
 
-	res, err := b.get(ctx, url)
+	res, err := get(ctx, url, b.client)
 	if err != nil {
 		return nil, err
 	}
@@ -1833,7 +1833,7 @@ func (b *Bridge) UpdateSensorContext(ctx context.Context, i int, sensor *Sensor)
 		return nil, err
 	}
 
-	res, err := b.put(ctx, url, data)
+	res, err := put(ctx, url, data, b.client)
 	if err != nil {
 		return nil, err
 	}
@@ -1867,7 +1867,7 @@ func (b *Bridge) DeleteSensorContext(ctx context.Context, i int) error {
 		return err
 	}
 
-	res, err := b.delete(ctx, url)
+	res, err := del(ctx, url, b.client)
 	if err != nil {
 		return err
 	}
@@ -1901,7 +1901,7 @@ func (b *Bridge) UpdateSensorConfigContext(ctx context.Context, i int, c interfa
 		return nil, err
 	}
 
-	res, err := b.put(ctx, url, data)
+	res, err := put(ctx, url, data, b.client)
 	if err != nil {
 		return nil, err
 	}
@@ -1940,7 +1940,7 @@ func (b *Bridge) GetCapabilitiesContext(ctx context.Context) (*Capabilities, err
 		return nil, err
 	}
 
-	res, err := b.get(ctx, url)
+	res, err := get(ctx, url, b.client)
 	if err != nil {
 		return nil, err
 	}

--- a/bridge.go
+++ b/bridge.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"net/url"
 	"path"
 	"strconv"
@@ -16,6 +17,8 @@ type Bridge struct {
 	Host string `json:"internalipaddress,omitempty"`
 	User string
 	ID   string `json:"id,omitempty"`
+
+	transport *http.Client
 }
 
 func (b *Bridge) getAPIPath(str ...string) (string, error) {
@@ -63,7 +66,7 @@ func (b *Bridge) GetConfigContext(ctx context.Context) (*Config, error) {
 		return nil, err
 	}
 
-	res, err := get(ctx, url)
+	res, err := b.get(ctx, url)
 	if err != nil {
 		return nil, err
 	}
@@ -133,7 +136,7 @@ func (b *Bridge) createUserWithContext(ctx context.Context, deviceType string, g
 		return nil, err
 	}
 
-	res, err := post(ctx, url, data)
+	res, err := b.post(ctx, url, data)
 	if err != nil {
 		return nil, err
 	}
@@ -191,7 +194,7 @@ func (b *Bridge) UpdateConfigContext(ctx context.Context, c *Config) (*Response,
 		return nil, err
 	}
 
-	res, err := put(ctx, url, data)
+	res, err := b.put(ctx, url, data)
 	if err != nil {
 		return nil, err
 	}
@@ -224,7 +227,7 @@ func (b *Bridge) DeleteUserContext(ctx context.Context, n string) error {
 		return err
 	}
 
-	res, err := delete(ctx, url)
+	res, err := b.delete(ctx, url)
 	if err != nil {
 		return err
 	}
@@ -255,7 +258,7 @@ func (b *Bridge) GetFullStateContext(ctx context.Context) (map[string]interface{
 		return nil, err
 	}
 
-	res, err := get(ctx, url)
+	res, err := b.get(ctx, url)
 	if err != nil {
 		return nil, err
 	}
@@ -289,7 +292,7 @@ func (b *Bridge) GetGroupsContext(ctx context.Context) ([]Group, error) {
 		return nil, err
 	}
 
-	res, err := get(ctx, url)
+	res, err := b.get(ctx, url)
 	if err != nil {
 		return nil, err
 	}
@@ -331,7 +334,7 @@ func (b *Bridge) GetGroupContext(ctx context.Context, i int) (*Group, error) {
 		return nil, err
 	}
 
-	res, err := get(ctx, url)
+	res, err := b.get(ctx, url)
 	if err != nil {
 		return nil, err
 	}
@@ -367,7 +370,7 @@ func (b *Bridge) SetGroupStateContext(ctx context.Context, i int, l State) (*Res
 		return nil, err
 	}
 
-	res, err := put(ctx, url, data)
+	res, err := b.put(ctx, url, data)
 	if err != nil {
 		return nil, err
 	}
@@ -406,7 +409,7 @@ func (b *Bridge) UpdateGroupContext(ctx context.Context, i int, l Group) (*Respo
 		return nil, err
 	}
 
-	res, err := put(ctx, url, data)
+	res, err := b.put(ctx, url, data)
 	if err != nil {
 		return nil, err
 	}
@@ -444,7 +447,7 @@ func (b *Bridge) CreateGroupContext(ctx context.Context, g Group) (*Response, er
 		return nil, err
 	}
 
-	res, err := post(ctx, url, data)
+	res, err := b.post(ctx, url, data)
 	if err != nil {
 		return nil, err
 	}
@@ -478,7 +481,7 @@ func (b *Bridge) DeleteGroupContext(ctx context.Context, i int) error {
 		return err
 	}
 
-	res, err := delete(ctx, url)
+	res, err := b.delete(ctx, url)
 	if err != nil {
 		return err
 	}
@@ -514,7 +517,7 @@ func (b *Bridge) GetLightsContext(ctx context.Context) ([]Light, error) {
 		return nil, err
 	}
 
-	res, err := get(ctx, url)
+	res, err := b.get(ctx, url)
 	if err != nil {
 		return nil, err
 	}
@@ -556,7 +559,7 @@ func (b *Bridge) GetLightContext(ctx context.Context, i int) (*Light, error) {
 		return nil, err
 	}
 
-	res, err := get(ctx, url)
+	res, err := b.get(ctx, url)
 	if err != nil {
 		return light, err
 	}
@@ -585,7 +588,7 @@ func (b *Bridge) IdentifyLightContext(ctx context.Context, i int) (*Response, er
 	if err != nil {
 		return nil, err
 	}
-	res, err := put(ctx, url, []byte(`{"alert":"select"}`))
+	res, err := b.put(ctx, url, []byte(`{"alert":"select"}`))
 	if err != nil {
 		return nil, err
 	}
@@ -626,7 +629,7 @@ func (b *Bridge) SetLightStateContext(ctx context.Context, i int, l State) (*Res
 	if err != nil {
 		return nil, err
 	}
-	res, err := put(ctx, url, data)
+	res, err := b.put(ctx, url, data)
 	if err != nil {
 		return nil, err
 	}
@@ -662,7 +665,7 @@ func (b *Bridge) FindLightsContext(ctx context.Context) (*Response, error) {
 		return nil, err
 	}
 
-	res, err := post(ctx, url, nil)
+	res, err := b.post(ctx, url, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -696,7 +699,7 @@ func (b *Bridge) GetNewLightsContext(ctx context.Context) (*NewLight, error) {
 		return nil, err
 	}
 
-	res, err := get(ctx, url)
+	res, err := b.get(ctx, url)
 	if err != nil {
 		return nil, err
 	}
@@ -739,7 +742,7 @@ func (b *Bridge) DeleteLightContext(ctx context.Context, i int) error {
 		return err
 	}
 
-	res, err := delete(ctx, url)
+	res, err := b.delete(ctx, url)
 	if err != nil {
 		return err
 	}
@@ -776,7 +779,7 @@ func (b *Bridge) UpdateLightContext(ctx context.Context, i int, light Light) (*R
 		return nil, err
 	}
 
-	res, err := put(ctx, url, data)
+	res, err := b.put(ctx, url, data)
 	if err != nil {
 		return nil, err
 	}
@@ -815,7 +818,7 @@ func (b *Bridge) GetResourcelinksContext(ctx context.Context) ([]*Resourcelink, 
 		return nil, err
 	}
 
-	res, err := get(ctx, url)
+	res, err := b.get(ctx, url)
 	if err != nil {
 		return nil, err
 	}
@@ -857,7 +860,7 @@ func (b *Bridge) GetResourcelinkContext(ctx context.Context, i int) (*Resourceli
 		return nil, err
 	}
 
-	res, err := get(ctx, url)
+	res, err := b.get(ctx, url)
 	if err != nil {
 		return nil, err
 	}
@@ -891,7 +894,7 @@ func (b *Bridge) CreateResourcelinkContext(ctx context.Context, s *Resourcelink)
 		return nil, err
 	}
 
-	res, err := post(ctx, url, data)
+	res, err := b.post(ctx, url, data)
 	if err != nil {
 		return nil, err
 	}
@@ -929,7 +932,7 @@ func (b *Bridge) UpdateResourcelinkContext(ctx context.Context, i int, resourcel
 		return nil, err
 	}
 
-	res, err := put(ctx, url, data)
+	res, err := b.put(ctx, url, data)
 	if err != nil {
 		return nil, err
 	}
@@ -963,7 +966,7 @@ func (b *Bridge) DeleteResourcelinkContext(ctx context.Context, i int) error {
 		return err
 	}
 
-	res, err := delete(ctx, url)
+	res, err := b.delete(ctx, url)
 	if err != nil {
 		return err
 	}
@@ -999,7 +1002,7 @@ func (b *Bridge) GetRulesContext(ctx context.Context) ([]*Rule, error) {
 		return nil, err
 	}
 
-	res, err := get(ctx, url)
+	res, err := b.get(ctx, url)
 	if err != nil {
 		return nil, err
 	}
@@ -1041,7 +1044,7 @@ func (b *Bridge) GetRuleContext(ctx context.Context, i int) (*Rule, error) {
 		return nil, err
 	}
 
-	res, err := get(ctx, url)
+	res, err := b.get(ctx, url)
 	if err != nil {
 		return nil, err
 	}
@@ -1075,7 +1078,7 @@ func (b *Bridge) CreateRuleContext(ctx context.Context, s *Rule) (*Response, err
 		return nil, err
 	}
 
-	res, err := post(ctx, url, data)
+	res, err := b.post(ctx, url, data)
 	if err != nil {
 		return nil, err
 	}
@@ -1114,7 +1117,7 @@ func (b *Bridge) UpdateRuleContext(ctx context.Context, i int, rule *Rule) (*Res
 		return nil, err
 	}
 
-	res, err := put(ctx, url, data)
+	res, err := b.put(ctx, url, data)
 	if err != nil {
 		return nil, err
 	}
@@ -1148,7 +1151,7 @@ func (b *Bridge) DeleteRuleContext(ctx context.Context, i int) error {
 		return err
 	}
 
-	res, err := delete(ctx, url)
+	res, err := b.delete(ctx, url)
 	if err != nil {
 		return err
 	}
@@ -1184,7 +1187,7 @@ func (b *Bridge) GetScenesContext(ctx context.Context) ([]Scene, error) {
 		return nil, err
 	}
 
-	res, err := get(ctx, url)
+	res, err := b.get(ctx, url)
 	if err != nil {
 		return nil, err
 	}
@@ -1220,7 +1223,7 @@ func (b *Bridge) GetSceneContext(ctx context.Context, i string) (*Scene, error) 
 		return nil, err
 	}
 
-	res, err := get(ctx, url)
+	res, err := b.get(ctx, url)
 	if err != nil {
 		return nil, err
 	}
@@ -1260,7 +1263,7 @@ func (b *Bridge) UpdateSceneContext(ctx context.Context, id string, s *Scene) (*
 		return nil, err
 	}
 
-	res, err := put(ctx, url, data)
+	res, err := b.put(ctx, url, data)
 	if err != nil {
 		return nil, err
 	}
@@ -1301,7 +1304,7 @@ func (b *Bridge) SetSceneLightStateContext(ctx context.Context, id string, iid i
 		return nil, err
 	}
 
-	res, err := put(ctx, url, data)
+	res, err := b.put(ctx, url, data)
 	if err != nil {
 		return nil, err
 	}
@@ -1342,7 +1345,7 @@ func (b *Bridge) RecallSceneContext(ctx context.Context, id string, gid int) (*R
 		return nil, err
 	}
 
-	res, err := put(ctx, url, data)
+	res, err := b.put(ctx, url, data)
 	if err != nil {
 		return nil, err
 	}
@@ -1380,7 +1383,7 @@ func (b *Bridge) CreateSceneContext(ctx context.Context, s *Scene) (*Response, e
 		return nil, err
 	}
 
-	res, err := post(ctx, url, data)
+	res, err := b.post(ctx, url, data)
 	if err != nil {
 		return nil, err
 	}
@@ -1413,7 +1416,7 @@ func (b *Bridge) DeleteSceneContext(ctx context.Context, id string) error {
 		return err
 	}
 
-	res, err := delete(ctx, url)
+	res, err := b.delete(ctx, url)
 	if err != nil {
 		return err
 	}
@@ -1449,7 +1452,7 @@ func (b *Bridge) GetSchedulesContext(ctx context.Context) ([]*Schedule, error) {
 		return nil, err
 	}
 
-	res, err := get(ctx, url)
+	res, err := b.get(ctx, url)
 	if err != nil {
 		return nil, err
 	}
@@ -1491,7 +1494,7 @@ func (b *Bridge) GetScheduleContext(ctx context.Context, i int) (*Schedule, erro
 		return nil, err
 	}
 
-	res, err := get(ctx, url)
+	res, err := b.get(ctx, url)
 	if err != nil {
 		return nil, err
 	}
@@ -1525,7 +1528,7 @@ func (b *Bridge) CreateScheduleContext(ctx context.Context, s *Schedule) (*Respo
 		return nil, err
 	}
 
-	res, err := post(ctx, url, data)
+	res, err := b.post(ctx, url, data)
 	if err != nil {
 		return nil, err
 	}
@@ -1564,7 +1567,7 @@ func (b *Bridge) UpdateScheduleContext(ctx context.Context, i int, schedule *Sch
 		return nil, err
 	}
 
-	res, err := put(ctx, url, data)
+	res, err := b.put(ctx, url, data)
 	if err != nil {
 		return nil, err
 	}
@@ -1598,7 +1601,7 @@ func (b *Bridge) DeleteScheduleContext(ctx context.Context, i int) error {
 		return err
 	}
 
-	res, err := delete(ctx, url)
+	res, err := b.delete(ctx, url)
 	if err != nil {
 		return err
 	}
@@ -1634,7 +1637,7 @@ func (b *Bridge) GetSensorsContext(ctx context.Context) ([]Sensor, error) {
 		return nil, err
 	}
 
-	res, err := get(ctx, url)
+	res, err := b.get(ctx, url)
 	if err != nil {
 		return nil, err
 	}
@@ -1674,7 +1677,7 @@ func (b *Bridge) GetSensorContext(ctx context.Context, i int) (*Sensor, error) {
 		return nil, err
 	}
 
-	res, err := get(ctx, url)
+	res, err := b.get(ctx, url)
 	if err != nil {
 		return r, err
 	}
@@ -1708,7 +1711,7 @@ func (b *Bridge) CreateSensorContext(ctx context.Context, s *Sensor) (*Response,
 		return nil, err
 	}
 
-	res, err := post(ctx, url, data)
+	res, err := b.post(ctx, url, data)
 	if err != nil {
 		return nil, err
 	}
@@ -1744,7 +1747,7 @@ func (b *Bridge) FindSensorsContext(ctx context.Context) (*Response, error) {
 		return nil, err
 	}
 
-	res, err := post(ctx, url, nil)
+	res, err := b.post(ctx, url, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1779,7 +1782,7 @@ func (b *Bridge) GetNewSensorsContext(ctx context.Context) (*NewSensor, error) {
 		return nil, err
 	}
 
-	res, err := get(ctx, url)
+	res, err := b.get(ctx, url)
 	if err != nil {
 		return nil, err
 	}
@@ -1830,7 +1833,7 @@ func (b *Bridge) UpdateSensorContext(ctx context.Context, i int, sensor *Sensor)
 		return nil, err
 	}
 
-	res, err := put(ctx, url, data)
+	res, err := b.put(ctx, url, data)
 	if err != nil {
 		return nil, err
 	}
@@ -1864,7 +1867,7 @@ func (b *Bridge) DeleteSensorContext(ctx context.Context, i int) error {
 		return err
 	}
 
-	res, err := delete(ctx, url)
+	res, err := b.delete(ctx, url)
 	if err != nil {
 		return err
 	}
@@ -1898,7 +1901,7 @@ func (b *Bridge) UpdateSensorConfigContext(ctx context.Context, i int, c interfa
 		return nil, err
 	}
 
-	res, err := put(ctx, url, data)
+	res, err := b.put(ctx, url, data)
 	if err != nil {
 		return nil, err
 	}
@@ -1937,7 +1940,7 @@ func (b *Bridge) GetCapabilitiesContext(ctx context.Context) (*Capabilities, err
 		return nil, err
 	}
 
-	res, err := get(ctx, url)
+	res, err := b.get(ctx, url)
 	if err != nil {
 		return nil, err
 	}

--- a/bridge.go
+++ b/bridge.go
@@ -18,7 +18,7 @@ type Bridge struct {
 	User string
 	ID   string `json:"id,omitempty"`
 
-	transport *http.Client
+	client *http.Client
 }
 
 func (b *Bridge) getAPIPath(str ...string) (string, error) {

--- a/bridge_test.go
+++ b/bridge_test.go
@@ -34,29 +34,6 @@ func TestLogin(t *testing.T) {
 	t.Logf("Name: %s, SwVersion: %s", c.Name, c.SwVersion)
 }
 
-func TestCustomLogin(t *testing.T) {
-	newTransport := httpmock.InitialTransport.(*http.Transport).Clone()
-	newTransport.DialContext = func(ctx context.Context, network, address string) (net.Conn, error) {
-		return proxy.Direct.Dial(network, address)
-	}
-	newClient := http.DefaultClient
-	newClient.Transport = newTransport
-
-	httpmock.ActivateNonDefault(newClient)
-
-	b := NewCustom(hostname, username, newClient)
-
-	c, err := b.GetConfig()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if c == nil {
-		t.Fatal("failed to get config")
-	}
-	t.Logf("Logged in and got config which means that we are authorized")
-	t.Logf("Name: %s, SwVersion: %s", c.Name, c.SwVersion)
-}
-
 func TestLoginUnauthorized(t *testing.T) {
 	b := New(hostname, "")
 	b = b.Login("invalid_password")
@@ -126,4 +103,27 @@ func TestBridge_deleteError(t *testing.T) {
 	b := &Bridge{client: http.DefaultClient}
 	_, err := b.delete(context.Background(), "invalid hostname")
 	assert.NotNil(t, err)
+}
+
+func TestCustomLogin(t *testing.T) {
+	newTransport := httpmock.InitialTransport.(*http.Transport).Clone()
+	newTransport.DialContext = func(ctx context.Context, network, address string) (net.Conn, error) {
+		return proxy.Direct.Dial(network, address)
+	}
+	newClient := http.DefaultClient
+	newClient.Transport = newTransport
+
+	httpmock.ActivateNonDefault(newClient)
+
+	b := NewCustom(hostname, username, newClient)
+
+	c, err := b.GetConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c == nil {
+		t.Fatal("failed to get config")
+	}
+	t.Logf("Logged in and got config which means that we are authorized")
+	t.Logf("Name: %s, SwVersion: %s", c.Name, c.SwVersion)
 }

--- a/bridge_test.go
+++ b/bridge_test.go
@@ -3,12 +3,14 @@ package huego
 import (
 	"context"
 	"fmt"
+	"net"
 	"net/http"
 	"strings"
 	"testing"
 
 	"github.com/jarcoal/httpmock"
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/net/proxy"
 )
 
 func ExampleBridge_CreateUser() {
@@ -32,14 +34,15 @@ func TestLogin(t *testing.T) {
 	t.Logf("Name: %s, SwVersion: %s", c.Name, c.SwVersion)
 }
 
-/*
 func TestCustomLogin(t *testing.T) {
-	newTransport := http.DefaultTransport.(*httpmock.MockTransport)
-	newTransport. = func(ctx context.Context, network, address string) (net.Conn, error) {
+	newTransport := httpmock.InitialTransport.(*http.Transport).Clone()
+	newTransport.DialContext = func(ctx context.Context, network, address string) (net.Conn, error) {
 		return proxy.Direct.Dial(network, address)
 	}
 	newClient := http.DefaultClient
 	newClient.Transport = newTransport
+
+	httpmock.ActivateNonDefault(newClient)
 
 	b := NewCustom(hostname, username, newClient)
 
@@ -53,7 +56,7 @@ func TestCustomLogin(t *testing.T) {
 	t.Logf("Logged in and got config which means that we are authorized")
 	t.Logf("Name: %s, SwVersion: %s", c.Name, c.SwVersion)
 }
-*/
+
 func TestLoginUnauthorized(t *testing.T) {
 	b := New(hostname, "")
 	b = b.Login("invalid_password")

--- a/bridge_test.go
+++ b/bridge_test.go
@@ -76,32 +76,28 @@ func TestBridge_getAPIPathError(t *testing.T) {
 func TestBridge_getError(t *testing.T) {
 	httpmock.Deactivate()
 	defer httpmock.Activate()
-	b := &Bridge{client: http.DefaultClient}
-	_, err := b.get(context.Background(), "invalid hostname")
+	_, err := get(context.Background(), "invalid hostname", http.DefaultClient)
 	assert.NotNil(t, err)
 }
 
 func TestBridge_putError(t *testing.T) {
 	httpmock.Deactivate()
 	defer httpmock.Activate()
-	b := &Bridge{client: http.DefaultClient}
-	_, err := b.put(context.Background(), "invalid hostname", []byte("huego"))
+	_, err := put(context.Background(), "invalid hostname", []byte("huego"), http.DefaultClient)
 	assert.NotNil(t, err)
 }
 
 func TestBridge_postError(t *testing.T) {
 	httpmock.Deactivate()
 	defer httpmock.Activate()
-	b := &Bridge{client: http.DefaultClient}
-	_, err := b.post(context.Background(), "invalid hostname", []byte("huego"))
+	_, err := post(context.Background(), "invalid hostname", []byte("huego"), http.DefaultClient)
 	assert.NotNil(t, err)
 }
 
 func TestBridge_deleteError(t *testing.T) {
 	httpmock.Deactivate()
 	defer httpmock.Activate()
-	b := &Bridge{client: http.DefaultClient}
-	_, err := b.delete(context.Background(), "invalid hostname")
+	_, err := del(context.Background(), "invalid hostname", http.DefaultClient)
 	assert.NotNil(t, err)
 }
 
@@ -115,7 +111,7 @@ func TestCustomLogin(t *testing.T) {
 
 	httpmock.ActivateNonDefault(newClient)
 
-	b := NewCustom(hostname, username, newClient)
+	b := NewWithClient(hostname, username, newClient)
 
 	c, err := b.GetConfig()
 	if err != nil {

--- a/bridge_test.go
+++ b/bridge_test.go
@@ -32,6 +32,28 @@ func TestLogin(t *testing.T) {
 	t.Logf("Name: %s, SwVersion: %s", c.Name, c.SwVersion)
 }
 
+/*
+func TestCustomLogin(t *testing.T) {
+	newTransport := http.DefaultTransport.(*httpmock.MockTransport)
+	newTransport. = func(ctx context.Context, network, address string) (net.Conn, error) {
+		return proxy.Direct.Dial(network, address)
+	}
+	newClient := http.DefaultClient
+	newClient.Transport = newTransport
+
+	b := NewCustom(hostname, username, newClient)
+
+	c, err := b.GetConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c == nil {
+		t.Fatal("failed to get config")
+	}
+	t.Logf("Logged in and got config which means that we are authorized")
+	t.Logf("Name: %s, SwVersion: %s", c.Name, c.SwVersion)
+}
+*/
 func TestLoginUnauthorized(t *testing.T) {
 	b := New(hostname, "")
 	b = b.Login("invalid_password")
@@ -74,7 +96,7 @@ func TestBridge_getAPIPathError(t *testing.T) {
 func TestBridge_getError(t *testing.T) {
 	httpmock.Deactivate()
 	defer httpmock.Activate()
-	b := &Bridge{transport: http.DefaultClient}
+	b := &Bridge{client: http.DefaultClient}
 	_, err := b.get(context.Background(), "invalid hostname")
 	assert.NotNil(t, err)
 }
@@ -82,7 +104,7 @@ func TestBridge_getError(t *testing.T) {
 func TestBridge_putError(t *testing.T) {
 	httpmock.Deactivate()
 	defer httpmock.Activate()
-	b := &Bridge{transport: http.DefaultClient}
+	b := &Bridge{client: http.DefaultClient}
 	_, err := b.put(context.Background(), "invalid hostname", []byte("huego"))
 	assert.NotNil(t, err)
 }
@@ -90,7 +112,7 @@ func TestBridge_putError(t *testing.T) {
 func TestBridge_postError(t *testing.T) {
 	httpmock.Deactivate()
 	defer httpmock.Activate()
-	b := &Bridge{transport: http.DefaultClient}
+	b := &Bridge{client: http.DefaultClient}
 	_, err := b.post(context.Background(), "invalid hostname", []byte("huego"))
 	assert.NotNil(t, err)
 }
@@ -98,7 +120,7 @@ func TestBridge_postError(t *testing.T) {
 func TestBridge_deleteError(t *testing.T) {
 	httpmock.Deactivate()
 	defer httpmock.Activate()
-	b := &Bridge{transport: http.DefaultClient}
+	b := &Bridge{client: http.DefaultClient}
 	_, err := b.delete(context.Background(), "invalid hostname")
 	assert.NotNil(t, err)
 }

--- a/bridge_test.go
+++ b/bridge_test.go
@@ -3,6 +3,7 @@ package huego
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"strings"
 	"testing"
 
@@ -73,27 +74,31 @@ func TestBridge_getAPIPathError(t *testing.T) {
 func TestBridge_getError(t *testing.T) {
 	httpmock.Deactivate()
 	defer httpmock.Activate()
-	_, err := get(context.Background(), "invalid hostname")
+	b := &Bridge{transport: http.DefaultClient}
+	_, err := b.get(context.Background(), "invalid hostname")
 	assert.NotNil(t, err)
 }
 
 func TestBridge_putError(t *testing.T) {
 	httpmock.Deactivate()
 	defer httpmock.Activate()
-	_, err := put(context.Background(), "invalid hostname", []byte("huego"))
+	b := &Bridge{transport: http.DefaultClient}
+	_, err := b.put(context.Background(), "invalid hostname", []byte("huego"))
 	assert.NotNil(t, err)
 }
 
 func TestBridge_postError(t *testing.T) {
 	httpmock.Deactivate()
 	defer httpmock.Activate()
-	_, err := post(context.Background(), "invalid hostname", []byte("huego"))
+	b := &Bridge{transport: http.DefaultClient}
+	_, err := b.post(context.Background(), "invalid hostname", []byte("huego"))
 	assert.NotNil(t, err)
 }
 
 func TestBridge_deleteError(t *testing.T) {
 	httpmock.Deactivate()
 	defer httpmock.Activate()
-	_, err := delete(context.Background(), "invalid hostname")
+	b := &Bridge{transport: http.DefaultClient}
+	_, err := b.delete(context.Background(), "invalid hostname")
 	assert.NotNil(t, err)
 }

--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,5 @@ go 1.13
 require (
 	github.com/jarcoal/httpmock v1.0.4
 	github.com/stretchr/testify v1.4.0
+	golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd
 )

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,13 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd h1:O7DYs+zxREGLKzKoMQrtrEacpb0ZVXA5rIwylE2Xchk=
+golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
+golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
+golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
+golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=

--- a/huego.go
+++ b/huego.go
@@ -94,7 +94,7 @@ func (b *Bridge) get(ctx context.Context, url string) ([]byte, error) {
 
 	req = req.WithContext(ctx)
 
-	res, err := b.transport.Do(req)
+	res, err := b.client.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -123,7 +123,7 @@ func (b *Bridge) put(ctx context.Context, url string, data []byte) ([]byte, erro
 
 	req.Header.Set(contentType, applicationJSON)
 
-	res, err := b.transport.Do(req)
+	res, err := b.client.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -152,7 +152,7 @@ func (b *Bridge) post(ctx context.Context, url string, data []byte) ([]byte, err
 
 	req.Header.Set(contentType, applicationJSON)
 
-	res, err := b.transport.Do(req)
+	res, err := b.client.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -179,7 +179,7 @@ func (b *Bridge) delete(ctx context.Context, url string) ([]byte, error) {
 
 	req.Header.Set(contentType, applicationJSON)
 
-	res, err := b.transport.Do(req)
+	res, err := b.client.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -266,24 +266,24 @@ func DiscoverContext(ctx context.Context) (*Bridge, error) {
 // u is a username known to the bridge. Use Discover() and CreateUser() to create a user.
 func New(h, u string) *Bridge {
 	return &Bridge{
-		Host:      h,
-		User:      u,
-		ID:        "",
-		transport: http.DefaultClient,
+		Host:   h,
+		User:   u,
+		ID:     "",
+		client: http.DefaultClient,
 	}
 }
 
-// NewCustom instantiates and returns a new Bridge.
-// New accepts hostname/ip address to the bridge (h) as well as an username (u).
+// NewCustom instantiates and returns a new Bridge with a custom HTTP client.
+// NewCustom accepts the same parameters as New, but with an additional acceptance of an http.Client.
 //
 // h may or may not be prefixed with http(s)://. For example http://192.168.1.20/ or 192.168.1.20.
 // u is a username known to the bridge. Use Discover() and CreateUser() to create a user.
 // Difference between New and NewCustom being the ability to implement your own http.RoundTripper for proxying.
-func NewCustom(h, u string, transport *http.RoundTripper) *Bridge {
+func NewCustom(h, u string, client *http.Client) *Bridge {
 	return &Bridge{
-		Host:      h,
-		User:      u,
-		ID:        "",
-		transport: http.DefaultClient,
+		Host:   h,
+		User:   u,
+		ID:     "",
+		client: client,
 	}
 }

--- a/huego.go
+++ b/huego.go
@@ -85,7 +85,7 @@ func unmarshal(data []byte, v interface{}) error {
 	return nil
 }
 
-func get(ctx context.Context, url string) ([]byte, error) {
+func (b *Bridge) get(ctx context.Context, url string) ([]byte, error) {
 
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
@@ -94,8 +94,7 @@ func get(ctx context.Context, url string) ([]byte, error) {
 
 	req = req.WithContext(ctx)
 
-	client := http.DefaultClient
-	res, err := client.Do(req)
+	res, err := b.transport.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -111,7 +110,7 @@ func get(ctx context.Context, url string) ([]byte, error) {
 	return body, nil
 }
 
-func put(ctx context.Context, url string, data []byte) ([]byte, error) {
+func (b *Bridge) put(ctx context.Context, url string, data []byte) ([]byte, error) {
 
 	body := strings.NewReader(string(data))
 
@@ -124,8 +123,7 @@ func put(ctx context.Context, url string, data []byte) ([]byte, error) {
 
 	req.Header.Set(contentType, applicationJSON)
 
-	client := http.DefaultClient
-	res, err := client.Do(req)
+	res, err := b.transport.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -141,7 +139,7 @@ func put(ctx context.Context, url string, data []byte) ([]byte, error) {
 
 }
 
-func post(ctx context.Context, url string, data []byte) ([]byte, error) {
+func (b *Bridge) post(ctx context.Context, url string, data []byte) ([]byte, error) {
 
 	body := strings.NewReader(string(data))
 
@@ -154,8 +152,7 @@ func post(ctx context.Context, url string, data []byte) ([]byte, error) {
 
 	req.Header.Set(contentType, applicationJSON)
 
-	client := http.DefaultClient
-	res, err := client.Do(req)
+	res, err := b.transport.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -171,7 +168,7 @@ func post(ctx context.Context, url string, data []byte) ([]byte, error) {
 
 }
 
-func delete(ctx context.Context, url string) ([]byte, error) {
+func (b *Bridge) delete(ctx context.Context, url string) ([]byte, error) {
 
 	req, err := http.NewRequest(http.MethodDelete, url, nil)
 	if err != nil {
@@ -182,8 +179,7 @@ func delete(ctx context.Context, url string) ([]byte, error) {
 
 	req.Header.Set(contentType, applicationJSON)
 
-	client := http.DefaultClient
-	res, err := client.Do(req)
+	res, err := b.transport.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -269,5 +265,25 @@ func DiscoverContext(ctx context.Context) (*Bridge, error) {
 // h may or may not be prefixed with http(s)://. For example http://192.168.1.20/ or 192.168.1.20.
 // u is a username known to the bridge. Use Discover() and CreateUser() to create a user.
 func New(h, u string) *Bridge {
-	return &Bridge{h, u, ""}
+	return &Bridge{
+		Host:      h,
+		User:      u,
+		ID:        "",
+		transport: http.DefaultClient,
+	}
+}
+
+// NewCustom instantiates and returns a new Bridge.
+// New accepts hostname/ip address to the bridge (h) as well as an username (u).
+//
+// h may or may not be prefixed with http(s)://. For example http://192.168.1.20/ or 192.168.1.20.
+// u is a username known to the bridge. Use Discover() and CreateUser() to create a user.
+// Difference between New and NewCustom being the ability to implement your own http.RoundTripper for proxying.
+func NewCustom(h, u string, transport *http.RoundTripper) *Bridge {
+	return &Bridge{
+		Host:      h,
+		User:      u,
+		ID:        "",
+		transport: http.DefaultClient,
+	}
 }

--- a/huego.go
+++ b/huego.go
@@ -85,7 +85,7 @@ func unmarshal(data []byte, v interface{}) error {
 	return nil
 }
 
-func (b *Bridge) get(ctx context.Context, url string) ([]byte, error) {
+func get(ctx context.Context, url string, client *http.Client) ([]byte, error) {
 
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
@@ -94,7 +94,7 @@ func (b *Bridge) get(ctx context.Context, url string) ([]byte, error) {
 
 	req = req.WithContext(ctx)
 
-	res, err := b.client.Do(req)
+	res, err := client.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -110,7 +110,7 @@ func (b *Bridge) get(ctx context.Context, url string) ([]byte, error) {
 	return body, nil
 }
 
-func (b *Bridge) put(ctx context.Context, url string, data []byte) ([]byte, error) {
+func put(ctx context.Context, url string, data []byte, client *http.Client) ([]byte, error) {
 
 	body := strings.NewReader(string(data))
 
@@ -123,7 +123,7 @@ func (b *Bridge) put(ctx context.Context, url string, data []byte) ([]byte, erro
 
 	req.Header.Set(contentType, applicationJSON)
 
-	res, err := b.client.Do(req)
+	res, err := client.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -139,7 +139,7 @@ func (b *Bridge) put(ctx context.Context, url string, data []byte) ([]byte, erro
 
 }
 
-func (b *Bridge) post(ctx context.Context, url string, data []byte) ([]byte, error) {
+func post(ctx context.Context, url string, data []byte, client *http.Client) ([]byte, error) {
 
 	body := strings.NewReader(string(data))
 
@@ -152,7 +152,7 @@ func (b *Bridge) post(ctx context.Context, url string, data []byte) ([]byte, err
 
 	req.Header.Set(contentType, applicationJSON)
 
-	res, err := b.client.Do(req)
+	res, err := client.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -168,8 +168,7 @@ func (b *Bridge) post(ctx context.Context, url string, data []byte) ([]byte, err
 
 }
 
-func (b *Bridge) delete(ctx context.Context, url string) ([]byte, error) {
-
+func del(ctx context.Context, url string, client *http.Client) ([]byte, error) {
 	req, err := http.NewRequest(http.MethodDelete, url, nil)
 	if err != nil {
 		return nil, err
@@ -179,7 +178,7 @@ func (b *Bridge) delete(ctx context.Context, url string) ([]byte, error) {
 
 	req.Header.Set(contentType, applicationJSON)
 
-	res, err := b.client.Do(req)
+	res, err := client.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -273,13 +272,13 @@ func New(h, u string) *Bridge {
 	}
 }
 
-// NewCustom instantiates and returns a new Bridge with a custom HTTP client.
-// NewCustom accepts the same parameters as New, but with an additional acceptance of an http.Client.
+// NewWithClient instantiates and returns a new Bridge with a custom HTTP client.
+// NewWithClient accepts the same parameters as New, but with an additional acceptance of an http.Client.
 //
 // h may or may not be prefixed with http(s)://. For example http://192.168.1.20/ or 192.168.1.20.
 // u is a username known to the bridge. Use Discover() and CreateUser() to create a user.
-// Difference between New and NewCustom being the ability to implement your own http.RoundTripper for proxying.
-func NewCustom(h, u string, client *http.Client) *Bridge {
+// Difference between New and NewWithClient being the ability to implement your own http.RoundTripper for proxying.
+func NewWithClient(h, u string, client *http.Client) *Bridge {
 	return &Bridge{
 		Host:   h,
 		User:   u,


### PR DESCRIPTION
**- What I did**
Added the ability to use a custom http.Client when interacting with bridges. My particular use-case comes from all of my lighting being segmented off, this allows for me to use my router as a middle-man via an SSH tunnel. However, I feel there are many, many use-cases. 

**- How I did it**
I created a new function similar to New called NewCustom, it is just about the same except for it allows you to pass in your own http.Client. I then refactored all of the unexported http functions (get, put etc) to be methods of Bridge. This allows them to function using http.DefaultClient during normal operations, but with the custom http.Client otherwise.

**- How to verify it**
I've not only verified that this works for my use-case, but frankly making the testcases work (I didn't realize how httpmock had worked until today) was more work than the modification itself. So I think CI does a pretty good job of verification :)

**- Description for the CHANGELOG**
```
## 1.0.3
* Added ability to use a custom http.Client
```